### PR TITLE
Updated README to clarify contents of the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This image is designed to be used in a micro-service environment. It consists of
 Starting Nextcloud php-fpm instance listening on port 9000 is as easy as the following:
 
 ```console
-$ docker run -d nextcloud
+$ docker run -d indiehosters/nextcloud
 ```
 
 Now you can get access to fpm running on port 9000 inside the container. If you want to access it from the internet, we recommend using a reverse proxy in front. You can install it directly on your machine or use an additional container (You can find more information on that on the docker-compose section). Once you have a reverse proxy, you can access Nextcloud at http://localhost/ and go through the wizard. 
@@ -37,3 +37,12 @@ The recommended minimal setup is using this image in combination with two contai
 A working example can be found at [IndieHosters/Nextcloud](https://github.com/indiehosters/nextcloud).
 
 If you want to access your Nextcloud from the internet we recommend configuring your reverse proxy to use encryption (for example via [let's Encrypt](https://letsencrypt.org/))
+
+## Update to a newer version
+
+To update your Nextcloud version you simply have to pull and start the new container.
+```console
+$ docker pull indiehosters/nextcloud
+$ docker run -d indiehosters/nextcloud
+```
+When you access your site the update wizard will show up.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A safe home for all your data. Access & share your files, calendars, contacts, m
 ![logo](https://github.com/nextcloud/docker/blob/master/logo.png)
 
 # How to use this image
+This image is designed to be used in a micro-service environment. It consists of the Nextcloud installation in an [php-fpm](https://hub.docker.com/_/php/) container. To use this image it must be combined with any webserver that can proxy the http requests to the FastCGI-port of the container.
 
 ## Start Nextcloud
 
@@ -14,9 +15,9 @@ Starting Nextcloud php-fpm instance listening on port 9000 is as easy as the fol
 $ docker run -d nextcloud
 ```
 
-Now you can get access to fpm running on port 9000 inside the container. If you want to access it from the Internets, we recommend using a reverse proxy in front. You can find more information on that on the docker-compose section. Once you have a reverse proxy, go to http://localhost/ and go through the wizard. By default this container uses SQLite for data storage, but the wizard should allow for connecting to an existing database.
+Now you can get access to fpm running on port 9000 inside the container. If you want to access it from the internet, we recommend using a reverse proxy in front. You can install it directly on your machine or use an additional container (You can find more information on that on the docker-compose section). Once you have a reverse proxy, you can access Nextcloud at http://localhost/ and go through the wizard. 
 
-For a MySQL database you can link an database container, e.g. `--link my-mysql:mysql`, and then use `mysql` as the database host on setup.
+By default this container uses SQLite for data storage, but the wizard allows connecting to an existing database. For a MySQL database you can link an database container, e.g. `--link my-mysql:mysql`, and then use `mysql` as the database host on setup.
 
 ## Persistent data
 
@@ -32,4 +33,7 @@ For fine grained data persistence, you can use 3 volumes, as shown below.
 
 ## ... via [`docker-compose`](https://github.com/docker/compose)
 
-You can use a setup that is used in production at [IndieHosters/Nextcloud](https://github.com/indiehosters/nextcloud).
+The recommended minimal setup is using this image in combination with two containers: A database container and a reverse proxy for the http connection to the service.
+A working example can be found at [IndieHosters/Nextcloud](https://github.com/indiehosters/nextcloud).
+
+If you want to access your Nextcloud from the internet we recommend configuring your reverse proxy to use encryption (for example via [let's Encrypt](https://letsencrypt.org/))


### PR DESCRIPTION
Hey,

I updated the readme a little bit and added some explanations. 

I also changed the container name in the run command to `indiehosters/nextcloud`, because there are neither an official dockerhub image nor a nextcloud organisation yet.

@pierreozoux please review.