### PR TITLE
Install LDAP PHP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
   libfreetype6-dev \
   libicu-dev \
   libjpeg-dev \
+  libldap2-dev \
   libmcrypt-dev \
   libmemcached-dev \
   libpng12-dev \
@@ -15,7 +16,8 @@ RUN apt-get update && apt-get install -y \
 
 # https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-  && docker-php-ext-install gd exif intl mbstring mcrypt mysql opcache pdo_mysql pdo_pgsql pgsql zip
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysql opcache pdo_mysql pdo_pgsql pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php


### PR DESCRIPTION
The LDAP extension is required for LDAP integration.

With this extension installed, I was able to upgrade and migrate fine from Owncloud 9.1 to Nextcloud 10 with this Docker image!

Note; I see that a lot of development libraries are installed and kept, including the libldap2-dev I add here. Multiple RUN commands are also run which prevents cleanup from reducing the size of the final Docker image. Would it be wanted with a PR with merging the RUN's and with cleanup?