### PR TITLE
version: move to separate versions and variants

### DIFF
--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-fpm
+FROM php:5.6-apache
 
 RUN apt-get update && apt-get install -y \
   bzip2 \
@@ -29,6 +29,7 @@ RUN { \
     echo 'opcache.fast_shutdown=1'; \
     echo 'opcache.enable_cli=1'; \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
 
 # PECL extensions
 RUN set -ex \
@@ -36,8 +37,9 @@ RUN set -ex \
  && pecl install memcached-2.2.0 \
  && pecl install redis-2.2.8 \
  && docker-php-ext-enable apcu redis memcached
+RUN a2enmod rewrite
 
-ENV NEXTCLOUD_VERSION 10.0.1
+ENV NEXTCLOUD_VERSION 10.0.2
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
@@ -55,4 +57,4 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
 COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["php-fpm"]
+CMD ["apache2-foreground"]

--- a/10.0/apache/docker-entrypoint.sh
+++ b/10.0/apache/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+    tar cf - --one-file-system -C /usr/src/nextcloud . | tar xf -
+    chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:5.6-fpm
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  libcurl4-openssl-dev \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg-dev \
+  libldap2-dev \
+  libmcrypt-dev \
+  libmemcached-dev \
+  libpng12-dev \
+  libpq-dev \
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
+RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysql opcache pdo_mysql pdo_pgsql pgsql zip
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-4.0.10 \
+ && pecl install memcached-2.2.0 \
+ && pecl install redis-2.2.8 \
+ && docker-php-ext-enable apcu redis memcached
+
+ENV NEXTCLOUD_VERSION 10.0.2
+VOLUME /var/www/html
+
+RUN curl -fsSL -o nextcloud.tar.bz2 \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
+ && curl -fsSL -o nextcloud.tar.bz2.asc \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+# gpg key from https://nextcloud.com/nextcloud.asc
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A \
+ && gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2 \
+ && rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc \
+ && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
+ && rm nextcloud.tar.bz2
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/10.0/fpm/docker-entrypoint.sh
+++ b/10.0/fpm/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+    tar cf - --one-file-system -C /usr/src/nextcloud . | tar xf -
+    chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -1,0 +1,60 @@
+FROM php:5.6-apache
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  libcurl4-openssl-dev \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg-dev \
+  libldap2-dev \
+  libmcrypt-dev \
+  libmemcached-dev \
+  libpng12-dev \
+  libpq-dev \
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
+RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysql opcache pdo_mysql pdo_pgsql pgsql zip
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-4.0.10 \
+ && pecl install memcached-2.2.0 \
+ && pecl install redis-2.2.8 \
+ && docker-php-ext-enable apcu redis memcached
+RUN a2enmod rewrite
+
+ENV NEXTCLOUD_VERSION 11.0.0
+VOLUME /var/www/html
+
+RUN curl -fsSL -o nextcloud.tar.bz2 \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
+ && curl -fsSL -o nextcloud.tar.bz2.asc \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+# gpg key from https://nextcloud.com/nextcloud.asc
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A \
+ && gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2 \
+ && rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc \
+ && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
+ && rm nextcloud.tar.bz2
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/11.0/apache/docker-entrypoint.sh
+++ b/11.0/apache/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+    tar cf - --one-file-system -C /usr/src/nextcloud . | tar xf -
+    chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:5.6-fpm
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  libcurl4-openssl-dev \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg-dev \
+  libldap2-dev \
+  libmcrypt-dev \
+  libmemcached-dev \
+  libpng12-dev \
+  libpq-dev \
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
+RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysql opcache pdo_mysql pdo_pgsql pgsql zip
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-4.0.10 \
+ && pecl install memcached-2.2.0 \
+ && pecl install redis-2.2.8 \
+ && docker-php-ext-enable apcu redis memcached
+
+ENV NEXTCLOUD_VERSION 11.0.0
+VOLUME /var/www/html
+
+RUN curl -fsSL -o nextcloud.tar.bz2 \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
+ && curl -fsSL -o nextcloud.tar.bz2.asc \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+# gpg key from https://nextcloud.com/nextcloud.asc
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A \
+ && gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2 \
+ && rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc \
+ && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
+ && rm nextcloud.tar.bz2
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/11.0/fpm/docker-entrypoint.sh
+++ b/11.0/fpm/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+    tar cf - --one-file-system -C /usr/src/nextcloud . | tar xf -
+    chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,60 @@
+FROM php:5.6-%%VARIANT%%
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  libcurl4-openssl-dev \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg-dev \
+  libldap2-dev \
+  libmcrypt-dev \
+  libmemcached-dev \
+  libpng12-dev \
+  libpq-dev \
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
+RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysql opcache pdo_mysql pdo_pgsql pgsql zip
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-4.0.10 \
+ && pecl install memcached-2.2.0 \
+ && pecl install redis-2.2.8 \
+ && docker-php-ext-enable apcu redis memcached
+RUN a2enmod rewrite
+
+ENV NEXTCLOUD_VERSION %%VERSION%%
+VOLUME /var/www/html
+
+RUN curl -fsSL -o nextcloud.tar.bz2 \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
+ && curl -fsSL -o nextcloud.tar.bz2.asc \
+    "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+# gpg key from https://nextcloud.com/nextcloud.asc
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A \
+ && gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2 \
+ && rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc \
+ && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
+ && rm nextcloud.tar.bz2
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["%%CMD%%"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,16 +1,81 @@
 #!/bin/bash
 set -e
 
+self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-url='git://github.com/nextcloud/docker'
+# Get the most recent commit which modified any of "$@".
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
 
-commit="$(git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
-fullVersion="$(grep -m1 'ENV NEXTCLOUD_VERSION ' ./Dockerfile | cut -d' ' -f3)"
+# Get the most recent commit which modified "$1/Dockerfile" or any file that
+# the Dockerfile copies into the rootfs (with COPY).
+dockerfileCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir";
+		fileCommit Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++)
+							print $i;
+				}
+			')
+	)
+}
 
-echo '# maintainer: docker@nextcloud.com'
-echo
-echo "$fullVersion: ${url}@${commit}"
-echo "${fullVersion%.*}: ${url}@${commit}"
-echo "${fullVersion%.*.*}: ${url}@${commit}"
-echo "latest: ${url}@${commit}"
+# Header.
+cat <<-EOH
+# This file is generated via https://github.com/nextcloud/docker/blob/$(fileCommit "$self")/$self
+
+Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud),
+             Pierre Ozoux <pierre@ozoux.net> (@pierreozoux)
+GitRepo: https://github.com/nextcloud/docker.git
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+latest=$(curl -sSL 'https://nextcloud.com/changelog/' |tac|tac \
+	   | grep -o "\(Version\|Release\)\s\+[[:digit:]]\+\(.[[:digit:]]\+\)\+" \
+	   | awk '{ print $2 }' \
+	   | sort -uV \
+	   | tail -1)
+
+# Generate each of the tags.
+versions=( */ )
+versions=( "${versions[@]%/}" )
+for version in "${versions[@]}"; do
+	variants=( $version/*/ )
+	variants=( $(for variant in "${variants[@]%/}"; do
+		echo "$(basename "$variant")"
+	done) )
+	for variant in "${variants[@]}"; do
+		commit="$(dockerfileCommit "$version/$variant")"
+		fullversion="$(git show "$commit":"$version/$variant/Dockerfile" | awk '$1 == "ENV" && $2 == "NEXTCLOUD_VERSION" { print $3; exit }')"
+
+		versionAliases=( "$fullversion" "${fullversion%.*}" "${fullversion%.*.*}" )
+		if [ "$fullversion" = "$latest" ]; then
+			versionAliases+=( "latest" )
+		fi
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-}" )
+
+		if [ "$variant" = "apache" ]; then
+			variantAliases+=( "${versionAliases[@]}" )
+		fi
+
+		cat <<-EOE
+
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
+	done
+done

--- a/update.sh
+++ b/update.sh
@@ -1,17 +1,38 @@
 #!/bin/bash
 set -eo pipefail
 
-current="$(
-	git ls-remote --tags https://github.com/nextcloud/server.git \
-		| awk -F 'refs/tags/' '
-			$2 ~ /^v?[0-9]/ {
-				gsub(/^v|\^.*/, "", $2);
-				print $2;
-			}
-		' \
-		| sort -uV \
-		| tail -1
-)"
+declare -A cmd=(
+	[apache]='apache2-foreground'
+	[fpm]='php-fpm'
+)
 
-set -x
-sed -ri 's/^(ENV NEXTCLOUD_VERSION) .*/\1 '"$current"'/;' ./Dockerfile
+latests=( $(curl -sSL 'https://nextcloud.com/changelog/' |tac|tac| \
+	grep -o "\(Version\|Release\)\s\+[[:digit:]]\+\(\.[[:digit:]]\+\)\+" | \
+	awk '{ print $2 }' | sort -V ) )
+
+for latest in "${latests[@]}"; do
+	version=$(echo "$latest" | cut -d. -f1-2)
+
+	for variant in apache fpm; do
+		# Create the version+variant directory with a Dockerfile.
+		mkdir -p "$version/$variant"
+		cp Dockerfile.template "$version/$variant/Dockerfile"
+
+		echo "updating $latest [$version] $variant"
+
+		# Replace the variables.
+		sed -ri -e '
+			s/%%VARIANT%%/'"$variant"'/g;
+			s/%%VERSION%%/'"$latest"'/g;
+			s/%%CMD%%/'"${cmd[$variant]}"'/g;
+		' "$version/$variant/Dockerfile"
+
+		# Remove Apache commands if we're not an Apache variant.
+		if [ "$variant" != "apache" ]; then
+			sed -ri -e '/a2enmod/d' "$version/$variant/Dockerfile"
+		fi
+
+		# Copy the docker-entrypoint.
+		cp docker-entrypoint.sh "$version/$variant/docker-entrypoint.sh"
+	done
+done


### PR DESCRIPTION
In order to match ownCloud's Docker images, we need to provide -apache
and -fpm variant images as well as maintaining version tags for older
images.

These scripts are improved versions of the ownCloud scripts[1] because
they also automatically generate the directories with each ./update.sh,
and also generate all aliases without needing human intervention.

[1]: https://github.com/docker-library/owncloud/blob/master/generate-stackbrew-library.sh

Fixes: #20
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>