### PR TITLE
Dockerfile: use correct VOLUMEs

### DIFF
--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 10.0.3
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 10.0.3
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 11.0.1
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 11.0.1
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/9.0/apache/Dockerfile
+++ b/9.0/apache/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 9.0.56
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/9.0/fpm/Dockerfile
+++ b/9.0/fpm/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 9.0.56
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -40,7 +40,7 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
-VOLUME /var/www/html
+VOLUME ["/var/www/html/data", "/var/www/html/config", "/var/www/html/apps"]
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \

--- a/README.md
+++ b/README.md
@@ -15,17 +15,13 @@ Starting Nextcloud php-fpm instance listening on port 9000 is as easy as the fol
 $ docker run -d indiehosters/nextcloud
 ```
 
-Now you can get access to fpm running on port 9000 inside the container. If you want to access it from the internet, we recommend using a reverse proxy in front. You can install it directly on your machine or use an additional container (You can find more information on that on the docker-compose section). Once you have a reverse proxy, you can access Nextcloud at http://localhost/ and go through the wizard. 
+Now you can get access to fpm running on port 9000 inside the container. If you want to access it from the internet, we recommend using a reverse proxy in front. You can install it directly on your machine or use an additional container (You can find more information on that on the docker-compose section). Once you have a reverse proxy, you can access Nextcloud at http://localhost/ and go through the wizard.
 
 By default this container uses SQLite for data storage, but the Nextcloud setup wizard (appears on first run) allows connecting to an existing MySQL/MariaDB or PostgreSQL database. You can also link a database container, e.g. `--link my-mysql:mysql`, and then use `mysql` as the database host on setup.
 
 ## Persistent data
 
-All data beyond that which lives in the database (file uploads, etc) is stored within the default volume `/var/www/html`. With this volume, Nextcloud will only be updated when the file `version.php` is not present.
-
-- `-v /<mydatalocation>:/var/www/html`
-
-For fine grained data persistence, you can use 3 volumes, as shown below.
+All data beyond that which lives in the database (file uploads, etc) is stored within several volumes, which are all separately controlled (to ensure that the source code of NextCloud can be updated by switching Docker versions -- please always follow the correct upgrade process despite the ease of just switching images):
 
 - `-v /<mydatalocation>/apps:/var/www/html/apps` installed / modified apps
 - `-v /<mydatalocation>/config:/var/www/html/config` local configuration


### PR DESCRIPTION
The persistent data is just the contents of config/ (configuration),
apps/ (installed apps), and data/ (user data). The source code should
not be made into a volume because it will cause persistence issues when
you try to update an image.

This matches how ownCloud's setup works as well.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>