### PR TITLE
Upgrade to Nextcloud 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
  && pecl install redis-2.2.8 \
  && docker-php-ext-enable apcu redis memcached
 
-ENV NEXTCLOUD_VERSION 10.0.1
+ENV NEXTCLOUD_VERSION 11.0.0
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \


### PR DESCRIPTION
I'm doing a fresh Nextcloud install and wanted to use the new version 11 and just replacing the version number in the Dockerfile seems to be working fine.

Or ist there some kind of upgrade function inside the image planned and that's why it's not updated yet? 

Anyway, thanks for the Dockerfile!