### PR TITLE
Added libpcre3-dev to make pcre.h available

### DIFF
--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
   libpng12-dev \
   libpq-dev \
   libxml2-dev \
+  libpcre3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html


### PR DESCRIPTION
Without pcre.h the build process will fail with the latest php:7.1-apache base image