### PR TITLE
[chore] dev env dockerfile draft

### DIFF
--- a/12.0/dev/Dockerfile
+++ b/12.0/dev/Dockerfile
@@ -1,0 +1,66 @@
+FROM php:7.1-apache
+
+RUN set -ex \
+  && buildDeps=" \
+    rsync \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    libfreetype6-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libldap2-dev \
+    libmcrypt-dev \
+    libmemcached-dev \
+    libpng12-dev \
+    libpq-dev \
+    libxml2-dev \
+  " \
+  && apt-get update \
+  && apt-get install -y $buildDeps --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+RUN set -ex \
+  && phpModules=" \
+    bz2 \
+    curl \
+    gd \
+    exif \
+    intl \
+    mbstring \
+    mcrypt \
+    ldap \
+    mysqli \
+    opcache \
+    pdo_mysql \
+    pdo_pgsql \
+    pgsql \
+    zip \
+  " \
+  && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install $phpModules
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+    echo 'opcache.enable=1'; \
+    echo 'opcache.enable_cli=1'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=10000'; \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.save_comments=1'; \
+    echo 'opcache.revalidate_freq=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-5.1.8 \
+ && pecl install memcached-3.0.2 \
+ && pecl install redis-3.1.1 \
+ && docker-php-ext-enable apcu redis memcached
+RUN a2enmod rewrite
+
+VOLUME /var/www/html
+CMD ["apache2-foreground"]


### PR DESCRIPTION
Hey Nexclouders!

for quick start development, I've made a `Dockerfile` to build a development docker environment. It's a first draft, based on the `apache` version that I rewrote a little bit. I now need your inputs to find how we can improve it :smiley:. So I have few questions:

1. yet, it excludes some PHP modules like
  - `smbclient`, `ftp` and `imap`
  - `gmp`
  - `memcached` and `redis`
  - `imagick` and the preview deps tools (`ffmpeg`, `avconv`, `LibreOffice`)
should we consider, as the image if for development purposes, that we need to provide them, or is it too much?

2. It actually uses a `sqlite` db for storage, which is fine for development I guess, but once again, if this image is used for development, we maybe need to also embed a MariaDB and a PgSQL, or at least give a simple way to compose a docker image with those DB, isn't it?

3. I see that the dockerfiles are generated from templates. I so could contribute to them for the `nextcloud:dev` dockerfile so I can be generated as well. Do it sounds good?

4. We can actually run it with `cd nextcloud/server && docker --rm -it -p 8080:80 -v $(pwd):/var/www/html nextcloud:dev`, but even if my proposal is a little bit different than the `apache` version, maybe the latter is sufficient for dev purposes, so this PR isn't really relevant. Any thoughts about it?

Thanks for your opinions!