### PR TITLE
Update README.md to use nextcloud:fpm image in FPM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ services:
       - MYSQL_USER=nextcloud
 
   app:
-    image: nextcloud
+    image: nextcloud:fpm
     links:
       - db
     volumes:


### PR DESCRIPTION
Fixed FPM example docker-compose to actually use nextcloud:fpm image instead of the default apache image