### PR TITLE
Ensure config/apps.config.php get copied

### DIFF
--- a/10.0/apache/docker-entrypoint.sh
+++ b/10.0/apache/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/10.0/fpm/docker-entrypoint.sh
+++ b/10.0/fpm/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/11.0/apache/docker-entrypoint.sh
+++ b/11.0/apache/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/11.0/fpm/docker-entrypoint.sh
+++ b/11.0/fpm/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/12.0/apache/docker-entrypoint.sh
+++ b/12.0/apache/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/12.0/fpm/docker-entrypoint.sh
+++ b/12.0/fpm/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,6 +35,10 @@ if version_greater "$image_version" "$installed_version"; then
         fi
     done
 
+    if [ ! -f /var/www/html/config/apps.config.php ]; then
+        cp -a /usr/src/nextcloud/config/apps.config.php /var/www/html/config/apps.config.php
+    fi
+
     if [ "$installed_version" != "0.0.0~unknown" ]; then
         su - www-data -s /bin/bash -c 'php /var/www/html/occ upgrade --no-app-disable'
 


### PR DESCRIPTION
PR #115 breaks the logic that config/apps.config.php get copied
after custom_apps: https://github.com/nextcloud/docker/pull/115#discussion_r124702790.

This patch is going to copy that file if it doesn't exist.