### PR TITLE
Example: Add container for cron job

### DIFF
--- a/.examples/docker-compose.yml
+++ b/.examples/docker-compose.yml
@@ -59,6 +59,26 @@ services:
       - proxy-tier
     restart: always
 
+  cron:
+    image: nextcloud:fpm
+    container_name: cron
+    links:
+      - db
+    volumes_from:
+      - app
+    user: www-data
+    entrypoint: |
+      bash -c 'bash -s <<EOF
+      trap "break;exit" SIGHUP SIGINT SIGTERM
+      while /bin/true; do
+        /usr/local/bin/php /var/www/html/cron.php
+        sleep 900
+      done
+      EOF'
+    networks:
+      - proxy-tier
+    restart: always
+
   db:
     image: mariadb
     container_name: db


### PR DESCRIPTION
Taking inspiration from the docker-compose made by indiehosters (https://github.com/indiehosters/nextcloud/blob/master/docker-compose.yml), this adds another service to the example docker-compose.yml that runs the cron job every 15 minutes.