### PR TITLE
Example: remove X-Frame-Options from nginx.conf

### DIFF
--- a/.examples/nginx.conf
+++ b/.examples/nginx.conf
@@ -17,7 +17,6 @@ http {
     # Add headers to serve security related headers
     add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
     add_header X-Content-Type-Options nosniff;
-    add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;


### PR DESCRIPTION
According to https://github.com/nextcloud/server/issues/4605, The X-Frame-Options should be dropped from nginx to let the php processing handle the case. On nextcloud 12, having that header in Nginx causes a warning in the admin panel.