### PR TITLE
update directory permissions to be compatible with non-root

### DIFF
--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -46,8 +46,6 @@ ENV NEXTCLOUD_VERSION 10.0.6
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -65,6 +63,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -43,7 +43,8 @@ RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 10.0.6
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -42,6 +42,8 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 10.0.6
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -58,16 +60,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -41,7 +41,8 @@ RUN set -ex \
 
 ENV NEXTCLOUD_VERSION 10.0.6
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -40,6 +40,8 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 10.0.6
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -56,16 +58,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -44,8 +44,6 @@ ENV NEXTCLOUD_VERSION 10.0.6
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -63,6 +61,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -43,6 +43,8 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 11.0.4
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -59,16 +61,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -44,7 +44,8 @@ RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 11.0.4
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -47,8 +47,6 @@ ENV NEXTCLOUD_VERSION 11.0.4
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -66,6 +64,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -41,6 +41,8 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 11.0.4
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -57,16 +59,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -45,8 +45,6 @@ ENV NEXTCLOUD_VERSION 11.0.4
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -64,6 +62,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -42,7 +42,8 @@ RUN set -ex \
 
 ENV NEXTCLOUD_VERSION 11.0.4
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -47,8 +47,6 @@ ENV NEXTCLOUD_VERSION 12.0.2
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -66,6 +64,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -44,7 +44,8 @@ RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 12.0.2
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -43,6 +43,8 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION 12.0.2
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -59,16 +61,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -42,7 +42,8 @@ RUN set -ex \
 
 ENV NEXTCLOUD_VERSION 12.0.2
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -41,6 +41,8 @@ RUN set -ex \
  && docker-php-ext-enable apcu redis memcached
 
 ENV NEXTCLOUD_VERSION 12.0.2
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -57,16 +59,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -45,8 +45,6 @@ ENV NEXTCLOUD_VERSION 12.0.2
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -64,6 +62,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/Dockerfile-php7.template
+++ b/Dockerfile-php7.template
@@ -44,7 +44,8 @@ RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \

--- a/Dockerfile-php7.template
+++ b/Dockerfile-php7.template
@@ -47,8 +47,6 @@ ENV NEXTCLOUD_VERSION %%VERSION%%
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -66,6 +64,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-php7.template
+++ b/Dockerfile-php7.template
@@ -43,6 +43,8 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -59,16 +61,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -42,6 +42,8 @@ RUN set -ex \
 RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
+
+RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
 COPY config/* /usr/src/nextcloud/config/
@@ -58,16 +60,8 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && tar -xjf nextcloud.tar.bz2 -C /usr/src/ \
  && rm nextcloud.tar.bz2 \
  && rm -rf /usr/src/nextcloud/updater \
- # https://docs.nextcloud.com/server/11/admin_manual/installation/installation_wizard.html#setting-strong-directory-permissions
  && mkdir -p /usr/src/nextcloud/data \
  && mkdir -p /usr/src/nextcloud/custom_apps \
- && find /usr/src/nextcloud/ -type f -print0 | xargs -0 chmod 0640 \
- && find /usr/src/nextcloud/ -type d -print0 | xargs -0 chmod 0750 \
- && chown -R root:www-data /usr/src/nextcloud/ \
- && chown -R www-data:www-data /usr/src/nextcloud/custom_apps/ \
- && chown -R www-data:www-data /usr/src/nextcloud/config/ \
- && chown -R www-data:www-data /usr/src/nextcloud/data/ \
- && chown -R www-data:www-data /usr/src/nextcloud/themes/ \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -46,8 +46,6 @@ ENV NEXTCLOUD_VERSION %%VERSION%%
 RUN chown -R www-data:root /var/www/html
 VOLUME /var/www/html
 
-COPY config/* /usr/src/nextcloud/config/
-
 RUN curl -fsSL -o nextcloud.tar.bz2 \
     "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2" \
  && curl -fsSL -o nextcloud.tar.bz2.asc \
@@ -65,6 +63,7 @@ RUN curl -fsSL -o nextcloud.tar.bz2 \
  && chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -43,7 +43,8 @@ RUN a2enmod rewrite
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
 
-RUN chown -R www-data:root /var/www/html
+RUN chown -R www-data:root /var/www/html && \
+    chmod -R g=u /var/www/html
 VOLUME /var/www/html
 
 RUN curl -fsSL -o nextcloud.tar.bz2 \


### PR DESCRIPTION
This commit updates the directory permissions to be more compatible when
running the image without root f.e. on OpenShift or when specifying it
when running with `docker run --user www-data:root ...`.
It adds detection logic to the entrypoint script as sudo is not always
allowed.

This change in directory permissions was also proposed by the official
documentation, see https://github.com/nextcloud/documentation/commit/22e2530.

The `chown` before the volume definition is needed to prepare the volume
as it inherits the permissions.

Closes #107 Closes #143 Closes #69