### PR TITLE
add client_max_body_size to upload files > 2 MB

### DIFF
--- a/.examples/uploadsize.conf
+++ b/.examples/uploadsize.conf
@@ -1,0 +1,1 @@
+client_max_body_size 10G;


### PR DESCRIPTION
With the current configuration i can only upload files < 2MB. If i upload bigger files i get the error message "Request Entity Too Large" back. I add the Solution from [SnowMB @issues/95](https://github.com/nextcloud/docker/issues/95#issuecomment-322683966)