### PR TITLE
add client_max_body_size to upload files > 2 MB

### DIFF
--- a/.examples/docker-compose.yml
+++ b/.examples/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./proxy/html:/usr/share/nginx/html
       - ./proxy/certs:/etc/nginx/certs:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./uploadsize.conf:/etc/nginx/conf.d/uploadsize.conf:ro
     networks:
       - proxy-tier
     restart: always


### PR DESCRIPTION
With the current configuration i can only upload files < 2MB. If i upload bigger files i get the error message "Request Entity Too Large" back. I add the Solution from [SnowMB @issues/95](https://github.com/nextcloud/docker/issues/95#issuecomment-322683966)