### PR TITLE
Allow compose to find all env variables

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
       - LETSENCRYPT_EMAIL=
-    environment:
       - MYSQL_HOST=db
     env_file:
       - db.env

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
       - LETSENCRYPT_EMAIL=
-    environment:
       - MYSQL_HOST=db
     env_file:
       - db.env

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
       - LETSENCRYPT_EMAIL=
-    environment:
       - POSTGRES_HOST=db
     env_file:
       - db.env


### PR DESCRIPTION
With two declared "environment" compose only takes the second one. In
thi case it means that the letsencrypt companion and reverse-proxy can't
read the neede variables for the setup, making this example to return a
http 503 error.