### PR TITLE
Add example in .examples section

### DIFF
--- a/.examples/README.md
+++ b/.examples/README.md
@@ -16,8 +16,51 @@ Example | Description
 [cron](https://github.com/nextcloud/docker/tree/master/.examples/dockerfiles/cron) | uses supervisor to run the cron job inside the container (so no extra container is needed).
 [imap](https://github.com/nextcloud/docker/tree/master/.examples/dockerfiles/imap) | adds dependencies required to authenticate users via imap
 [smb](https://github.com/nextcloud/docker/tree/master/.examples/dockerfiles/smb) | adds dependencies required to use smb shares
+[full](https://github.com/nextcloud/docker/tree/master/.examples/dockerfiles/full) | adds dependencies for ALL optional packages and cron functionality via supervisor (as in the `cron` example Dockerfile).
 
+### full
+The `full` Dockerfile example adds dependencies for all optional packages suggested by nextcloud that may be needed for some features (e.g. Video Preview Generation), as stated in the [Administration Manual](https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html).
 
+NOTE: The Dockerfile does not install the LibreOffice package (line is commented), because it would increase the generated Image size by approximately 500 MB. In order to install it, simply uncomment the 14th line of the Dockerfile.
+
+The required steps for each optional/recommended package that is not already in the Nextcloud image are listed here, so that the Dockerfile can easily be modified to only install the needed extra packages. Simply remove the steps for the unwanted packages  from the Dockerfile.
+
+#### PHP Module bz2
+`docker-php-ext-install bz2` </br>
+
+#### PHP Module imagick
+`apt install libmagickwand-dev` </br>
+`pecl install imagick` </br>
+`docker-php-ext-enable imagick` </br>
+
+#### PHP Module imap
+`apt install libc-client-dev libkrb5-dev` </br>
+`docker-php-ext-configure imap --with-kerberos --with-imap-ssl` </br>
+`docker-php-ext-install imap` </br>
+
+#### PHP Module gmp
+`apt install libgmp3-dev` </br>
+`docker-php-ext-install gmp` </br>
+
+#### PHP Module smbclient
+`apt install smbclient libsmbclient-dev` </br>
+`pecl install smbclient` </br>
+`docker-php-ext-enable smbclient` </br>
+
+#### ffmpeg
+`echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list` </br>
+`apt install ffmpeg` </br>
+
+#### LibreOffice
+`apt install LibreOffice` </br>
+
+#### CRON via supervisor
+`apt install supervisor cron` </br>
+`mkdir /var/log/supervisord /var/run/supervisord` </br>
+`echo "*/15 * * * * su - www-data -s /bin/bash -c \"php -f /var/www/html/cron.php\""| crontab -` </br>
+The following Dockerfile commands are also necessary for a sucessfull cron installation: </br>
+`COPY supervisord.conf /etc/supervisor/supervisord.conf` </br>
+`CMD ["/usr/bin/supervisord"]` </br>
 
 
 

--- a/.examples/README.md
+++ b/.examples/README.md
@@ -21,7 +21,11 @@ Example | Description
 ### full
 The `full` Dockerfile example adds dependencies for all optional packages suggested by nextcloud that may be needed for some features (e.g. Video Preview Generation), as stated in the [Administration Manual](https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html).
 
-NOTE: The Dockerfile does not install the LibreOffice package (line is commented), because it would increase the generated Image size by approximately 500 MB. In order to install it, simply uncomment the 14th line of the Dockerfile.
+NOTE: The Dockerfile does not install the LibreOffice package (line is commented), because it would increase the generated Image size by approximately 500 MB. In order to install it, simply uncomment the 14th line of the Dockerfile.</br>
+
+NOTE: Per default, only previews for BMP, GIF, JPEG, MarkDown, MP3, PNG, TXT, and XBitmap Files are generated. The configuration of the preview generation can be done in config.php, as explained in the [Administration Manual](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/config_sample_php_parameters.html#previews)</br>
+
+NOTE: Nextcloud recommends [disabling preview generation](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/harden_server.html?highlight=enabledpreviewproviders#disable-preview-image-generation) for high security deployments, as preview generation opens your nextcloud instance to new possible attack vectors.</br>
 
 The required steps for each optional/recommended package that is not already in the Nextcloud image are listed here, so that the Dockerfile can easily be modified to only install the needed extra packages. Simply remove the steps for the unwanted packages  from the Dockerfile.
 

--- a/.examples/dockerfiles/full/apache/Dockerfile
+++ b/.examples/dockerfiles/full/apache/Dockerfile
@@ -14,6 +14,7 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
 #       LibreOffice \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && ln -s "/usr/include/$(dpkg-architecture --query DEB_BUILD_MULTIARCH)/gmp.h" /usr/include/gmp.h \
     && docker-php-ext-install bz2 gmp imap \
     && pecl install imagick smbclient \
     && docker-php-ext-enable imagick smbclient \

--- a/.examples/dockerfiles/full/apache/Dockerfile
+++ b/.examples/dockerfiles/full/apache/Dockerfile
@@ -1,0 +1,25 @@
+FROM nextcloud:apache
+
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
+    && apt-get update && apt-get install -y \
+        supervisor \
+        cron \
+        ffmpeg \
+        libmagickwand-dev \
+        libgmp3-dev \
+        libc-client-dev \
+        libkrb5-dev \
+        smbclient \
+        libsmbclient-dev \
+#       LibreOffice \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install bz2 gmp imap \
+    && pecl install imagick smbclient \
+    && docker-php-ext-enable imagick smbclient \
+    && mkdir /var/log/supervisord /var/run/supervisord \
+    && echo "*/15 * * * * su - www-data -s /bin/bash -c \"php -f /var/www/html/cron.php\""| crontab -
+
+COPY supervisord.conf /etc/supervisor/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]

--- a/.examples/dockerfiles/full/apache/supervisord.conf
+++ b/.examples/dockerfiles/full/apache/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord/supervisord.log
+pidfile=/var/run/supervisord/supervisord.pid
+childlogdir=/var/log/supervisord/
+logfile_maxbytes=50MB                           ; maximum size of logfile before rotation
+logfile_backups=10                              ; number of backed up logfiles
+loglevel=error
+
+[program:php-fpm]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=php-fpm
+
+[program:cron]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=cron -f

--- a/.examples/dockerfiles/full/apache/supervisord.conf
+++ b/.examples/dockerfiles/full/apache/supervisord.conf
@@ -7,12 +7,12 @@ logfile_maxbytes=50MB                           ; maximum size of logfile before
 logfile_backups=10                              ; number of backed up logfiles
 loglevel=error
 
-[program:php-fpm]
+[program:apache2]
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-command=php-fpm
+command=apache2-foreground
 
 [program:cron]
 stdout_logfile=/dev/stdout

--- a/.examples/dockerfiles/full/fpm/Dockerfile
+++ b/.examples/dockerfiles/full/fpm/Dockerfile
@@ -1,0 +1,25 @@
+FROM nextcloud:fpm
+
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
+    && apt-get update && apt-get install -y \
+        supervisor \
+        cron \
+        ffmpeg \
+        libmagickwand-dev \
+        libgmp3-dev \
+        libc-client-dev \
+        libkrb5-dev \
+        smbclient \
+        libsmbclient-dev \
+#       LibreOffice \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install bz2 gmp imap \
+    && pecl install imagick smbclient \
+    && docker-php-ext-enable imagick smbclient \
+    && mkdir /var/log/supervisord /var/run/supervisord \
+    && echo "*/15 * * * * su - www-data -s /bin/bash -c \"php -f /var/www/html/cron.php\""| crontab -
+
+COPY supervisord.conf /etc/supervisor/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]

--- a/.examples/dockerfiles/full/fpm/Dockerfile
+++ b/.examples/dockerfiles/full/fpm/Dockerfile
@@ -14,6 +14,7 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/so
 #       LibreOffice \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && ln -s "/usr/include/$(dpkg-architecture --query DEB_BUILD_MULTIARCH)/gmp.h" /usr/include/gmp.h \
     && docker-php-ext-install bz2 gmp imap \
     && pecl install imagick smbclient \
     && docker-php-ext-enable imagick smbclient \

--- a/.examples/dockerfiles/full/fpm/supervisord.conf
+++ b/.examples/dockerfiles/full/fpm/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord/supervisord.log
+pidfile=/var/run/supervisord/supervisord.pid
+childlogdir=/var/log/supervisord/
+logfile_maxbytes=50MB                           ; maximum size of logfile before rotation
+logfile_backups=10                              ; number of backed up logfiles
+loglevel=error
+
+[program:php-fpm]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=php-fpm
+
+[program:cron]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=cron -f


### PR DESCRIPTION
This example adds dependencies for ALL optional nextcloud packages.
Also, the README.md was updated to detail the steps needed for each individual package, so users can easily modify the Dockerfile to their needs.

fixes #63 