### PR TITLE
 use php 7.1.13-apache image

### DIFF
--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.1.13-apache
 
 RUN set -ex; \
     apt-get update; \
@@ -87,6 +87,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 COPY config/* /usr/src/nextcloud/config/
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
to fix some issues with php 7.1.12
https://help.nextcloud.com/t/php-error-narrowing-occurred-during-type-inference/24010/15