### PR TITLE
Make container scripts posix compliant

### DIFF
--- a/11.0/apache/cron.sh
+++ b/11.0/apache/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/11.0/apache/entrypoint.sh
+++ b/11.0/apache/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/11.0/fpm-alpine/Dockerfile
+++ b/11.0/fpm-alpine/Dockerfile
@@ -4,8 +4,6 @@ FROM php:7.1-fpm-alpine
 RUN set -ex; \
     \
     apk add --no-cache \
-        bash \
-        coreutils \
         rsync \
     ; \
     \

--- a/11.0/fpm-alpine/cron.sh
+++ b/11.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/11.0/fpm-alpine/entrypoint.sh
+++ b/11.0/fpm-alpine/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/11.0/fpm/cron.sh
+++ b/11.0/fpm/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/11.0/fpm/entrypoint.sh
+++ b/11.0/fpm/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/12.0/apache/cron.sh
+++ b/12.0/apache/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -4,8 +4,6 @@ FROM php:7.1-fpm-alpine
 RUN set -ex; \
     \
     apk add --no-cache \
-        bash \
-        coreutils \
         rsync \
     ; \
     \

--- a/12.0/fpm-alpine/cron.sh
+++ b/12.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/12.0/fpm/cron.sh
+++ b/12.0/fpm/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/13.0/apache/cron.sh
+++ b/13.0/apache/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -4,8 +4,6 @@ FROM php:7.1-fpm-alpine
 RUN set -ex; \
     \
     apk add --no-cache \
-        bash \
-        coreutils \
         rsync \
     ; \
     \

--- a/13.0/fpm-alpine/cron.sh
+++ b/13.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/13.0/fpm/cron.sh
+++ b/13.0/fpm/cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -4,8 +4,6 @@ FROM php:%%PHP_VERSION%%-%%VARIANT%%
 RUN set -ex; \
     \
     apk add --no-cache \
-        bash \
-        coreutils \
         rsync \
     ; \
     \

--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 exec busybox crond -f -l 0 -L /dev/stdout

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,29 +1,31 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # version_greater A B returns whether A > B
-function version_greater() {
-	[[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]];
+version_greater() {
+	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
 # return true if specified directory is empty
-function directory_empty() {
-    [ -n "$(find "$1"/ -prune -empty)" ]
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
 }
 
-function run_as() {
-  if [[ $EUID -eq 0 ]]; then
-    su - www-data -s /bin/bash -c "$1"
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su - www-data -s /bin/sh -c "$1"
   else
-    bash -c "$1"
+    sh -c "$1"
   fi
 }
 
-installed_version="0.0.0~unknown"
+installed_version="0.0.0.0"
 if [ -f /var/www/html/version.php ]; then
-    installed_version=$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')
+    # shellcheck disable=SC2016
+    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-image_version=$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')
+# shellcheck disable=SC2016
+image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
 if version_greater "$installed_version" "$image_version"; then
     echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -31,10 +33,10 @@ if version_greater "$installed_version" "$image_version"; then
 fi
 
 if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_before
+    if [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
     fi
-    if [[ $EUID -eq 0 ]]; then
+    if [ "$(id -u)" = 0 ]; then
       rsync_options="-rlDog --chown www-data:root"
     else
       rsync_options="-rlD"
@@ -42,17 +44,17 @@ if version_greater "$image_version" "$installed_version"; then
     rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
     for dir in config data custom_apps themes; do
-        if [ ! -d /var/www/html/"$dir" ] || directory_empty /var/www/html/"$dir"; then
-            rsync $rsync_options --include /"$dir"/ --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         fi
     done
 
-    if [ "$installed_version" != "0.0.0~unknown" ]; then
+    if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade --no-app-disable'
 
-        run_as 'php /var/www/html/occ app:list' > /tmp/list_after
+        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"
-        diff <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_before) <(sed -n "/Enabled:/,/Disabled:/p" /tmp/list_after) | grep '<' | cut -d- -f2 | cut -d: -f1
+        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
         rm -f /tmp/list_before /tmp/list_after
     fi
 fi


### PR DESCRIPTION
Allows the scripts to run natively in the alpine container.
This allows us to remove the bash dependency of the alpine image, which saves about 6MB.

It should also fix #282 