### PR TITLE
Dockerfile: redirect the contributor to update.sh

### DIFF
--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-apache
 
 # entrypoint.sh and cron.sh dependencies

--- a/11.0/fpm-alpine/Dockerfile
+++ b/11.0/fpm-alpine/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
 FROM php:7.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies

--- a/11.0/fpm/Dockerfile
+++ b/11.0/fpm/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-fpm
 
 # entrypoint.sh and cron.sh dependencies

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-apache
 
 # entrypoint.sh and cron.sh dependencies

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
 FROM php:7.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-fpm
 
 # entrypoint.sh and cron.sh dependencies

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-apache
 
 # entrypoint.sh and cron.sh dependencies

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
 FROM php:7.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -1,3 +1,4 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.1-fpm
 
 # entrypoint.sh and cron.sh dependencies

--- a/update.sh
+++ b/update.sh
@@ -55,7 +55,10 @@ function create_variant() {
 	# Create the version+variant directory with a Dockerfile.
 	mkdir -p "$dir"
 
-	cp "Dockerfile-${base[$variant]}.template" "$dir/Dockerfile"
+        template="Dockerfile-${base[$variant]}.template"
+        rm -f "$dir/Dockerfile"
+        echo "# DO NOT EDIT: created by update.sh from $template" > "$dir/Dockerfile"
+	cat "$template" >> "$dir/Dockerfile"
 
 	echo "updating $fullversion [$1] $variant"
 
@@ -71,6 +74,8 @@ function create_variant() {
 		s/%%MEMCACHED_VERSION%%/'"${pecl_versions[memcached]}"'/g;
 		s/%%REDIS_VERSION%%/'"${pecl_versions[redis]}"'/g;
 	' "$dir/Dockerfile"
+        # remove write permission as a reminder this file must be modified with this script
+        chmod -w "$dir/Dockerfile"
 
 	# Copy the shell scripts
 	for name in entrypoint cron; do


### PR DESCRIPTION
The `*/*/Dockerfile` are created from `Docker*template` by the
update.sh script. We add a comment at the beginning of the file with
information to find their origin. We also make them readonly to remind
people who would like to improve these files that they are not meant
to be modified.