### PR TITLE
update.sh: do not chmod -w Dockerfile

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -56,7 +56,6 @@ function create_variant() {
 	mkdir -p "$dir"
 
         template="Dockerfile-${base[$variant]}.template"
-        rm -f "$dir/Dockerfile"
         echo "# DO NOT EDIT: created by update.sh from $template" > "$dir/Dockerfile"
 	cat "$template" >> "$dir/Dockerfile"
 
@@ -74,8 +73,6 @@ function create_variant() {
 		s/%%MEMCACHED_VERSION%%/'"${pecl_versions[memcached]}"'/g;
 		s/%%REDIS_VERSION%%/'"${pecl_versions[redis]}"'/g;
 	' "$dir/Dockerfile"
-        # remove write permission as a reminder this file must be modified with this script
-        chmod -w "$dir/Dockerfile"
 
 	# Copy the shell scripts
 	for name in entrypoint cron; do


### PR DESCRIPTION
In 18db7e679fd92e2d36d6113b1e174e6f1afda2d6 the Dockerfile write
permissions were removed to help remind the new contributor that they
should not be modified. However git does not keep that information (it
only keeps the executable bit in the file permissions), therefore
someone with a fresh clone will not have a file that is read-only.

Removing the write permission will however be a problem for anyone
running the update.sh script twice: it will fail to remove the files
because it uses rm -r instead of rm -fr.

Instead of fixing the removale to use the force flag, we revert the
modification that remove the write permission since it does not
actually help anyone.