### PR TITLE
update.sh: prevent apache out of memory

### DIFF
--- a/11.0/apache/Dockerfile
+++ b/11.0/apache/Dockerfile
@@ -102,7 +102,8 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    a2enconf remoteip;\
+    sed -i -e "s/MaxRequestWorkers.* 150/MaxRequestWorkers 30/" /etc/apache2/mods-available/mpm_prefork.conf
 
 ENV NEXTCLOUD_VERSION 11.0.8
 

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -102,7 +102,8 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    a2enconf remoteip;\
+    sed -i -e "s/MaxRequestWorkers.* 150/MaxRequestWorkers 30/" /etc/apache2/mods-available/mpm_prefork.conf
 
 ENV NEXTCLOUD_VERSION 12.0.6
 

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -102,7 +102,8 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    a2enconf remoteip;\
+    sed -i -e "s/MaxRequestWorkers.* 150/MaxRequestWorkers 30/" /etc/apache2/mods-available/mpm_prefork.conf
 
 ENV NEXTCLOUD_VERSION 13.0.1
 

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip;\\\n    sed -i -e "s/MaxRequestWorkers.* 150/MaxRequestWorkers 30/" /etc/apache2/mods-available/mpm_prefork.conf'
 	[fpm]=''
 	[fpm-alpine]=''
 )


### PR DESCRIPTION
With a default number of workers set to 150, the example apache
configuration will use over 4GB of RAM in the following, rather
likely, demonstration scenario:

* sync a directory with 1000 photos in one directory from a desktop to
  nextCloud
* go to the web interface and quickly scroll down to the bottom of the
  list of photos that were just uploaded
* apache will run as many apache workers as possible (150) to create
  thumbnails and use over 4GB of RAM

The default number of workers is reduced to 30 which has been
experienced to fit in a 2GB virtual machine. It takes longer to
complete but does not trigger out of memory problems.