### PR TITLE
Fix app-directory order so that shipped apps can be updated

### DIFF
--- a/.config/apps.config.php
+++ b/.config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/12.0/apache/config/apps.config.php
+++ b/12.0/apache/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/12.0/fpm-alpine/config/apps.config.php
+++ b/12.0/fpm-alpine/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/12.0/fpm/config/apps.config.php
+++ b/12.0/fpm/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/13.0/apache/config/apps.config.php
+++ b/13.0/apache/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/13.0/fpm-alpine/config/apps.config.php
+++ b/13.0/fpm-alpine/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );

--- a/13.0/fpm/config/apps.config.php
+++ b/13.0/fpm/config/apps.config.php
@@ -2,14 +2,14 @@
 $CONFIG = array (
   "apps_paths" => array (
       0 => array (
-              "path"     => OC::$SERVERROOT."/apps",
-              "url"      => "/apps",
-              "writable" => false,
-      ),
-      1 => array (
               "path"     => OC::$SERVERROOT."/custom_apps",
               "url"      => "/custom_apps",
               "writable" => true,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
       ),
   ),
 );


### PR DESCRIPTION
The configuration as used, albeit suggested in the Nextcloud admin manual, does not work correctly. There is a current example. Nextcloud 13.0.1 ships with files_pdfviewer 1.2.0, but an update to 1.2.1 is available. However when the app is updated, while 1.2.1 is installed into the custom_apps folder, it is not actually used because Nextcloud will still load 1.2.0 from the first app folder. By changing the order of the two app folders, everything works as it should be. Additional apps and updates are put into the custom_apps folder. 

This is arguably a bug in the server but I am not sure about that.