### PR TITLE
Cleanup php modules

### DIFF
--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -43,14 +43,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -37,14 +37,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -43,14 +43,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -43,14 +43,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -37,14 +37,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -43,14 +43,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -36,14 +36,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -42,14 +42,11 @@ RUN set -ex; \
         gd \
         intl \
         ldap \
-        mbstring \
         mcrypt \
-        mysqli \
         opcache \
         pcntl \
         pdo_mysql \
         pdo_pgsql \
-        pgsql \
         zip \
     ; \
     pecl install \


### PR DESCRIPTION
Removed:
- `mbstring` because it is already part of the base image
- `mysqli` because nextcloud>=12 requires only `pdo_mysql`
- `pgsql` because nextcloud>=12 requires only `pdo_pgsql`

This saves about 4 MB for the debian based image and 2 MB for the alpine based one