### PR TITLE
 Fix a race condition caused by the gpg-agent

### DIFF
--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -120,9 +120,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -99,9 +99,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -112,9 +112,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -120,9 +120,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -99,9 +99,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -112,9 +112,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -98,9 +98,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -111,9 +111,8 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    rm nextcloud.tar.bz2; \
+    rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \
     mkdir -p /usr/src/nextcloud/data; \
     mkdir -p /usr/src/nextcloud/custom_apps; \


### PR DESCRIPTION
This should fix this error:
```
+ rm -r /tmp/tmp.hgIZwWOiO2 nextcloud.tar.bz2.asc
rm: cannot remove '/tmp/tmp.hgIZwWOiO2/S.gpg-agent.browser': No such file or directory
```