### PR TITLE
 Kill the gpg-agent

### DIFF
--- a/12.0-rc/apache/Dockerfile
+++ b/12.0-rc/apache/Dockerfile
@@ -121,6 +121,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/12.0-rc/fpm-alpine/Dockerfile
+++ b/12.0-rc/fpm-alpine/Dockerfile
@@ -100,6 +100,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/12.0-rc/fpm/Dockerfile
+++ b/12.0-rc/fpm/Dockerfile
@@ -113,6 +113,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -121,6 +121,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -100,6 +100,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -113,6 +113,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0-rc/apache/Dockerfile
+++ b/13.0-rc/apache/Dockerfile
@@ -121,6 +121,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0-rc/fpm-alpine/Dockerfile
+++ b/13.0-rc/fpm-alpine/Dockerfile
@@ -100,6 +100,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0-rc/fpm/Dockerfile
+++ b/13.0-rc/fpm/Dockerfile
@@ -113,6 +113,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -121,6 +121,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -100,6 +100,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -113,6 +113,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -99,6 +99,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -112,6 +112,7 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    busybox killall gpg-agent || true; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     rm -rf /usr/src/nextcloud/updater; \


### PR DESCRIPTION
This should finally fix this error:
```
+ rm -r /tmp/tmp.hgIZwWOiO2 nextcloud.tar.bz2.asc
rm: cannot remove '/tmp/tmp.hgIZwWOiO2/S.gpg-agent.browser': No such file or directory
```