### PR TITLE
Remove the `/var/www/html` volume

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -80,7 +80,6 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
@@ -99,17 +98,36 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    tar -xjf nextcloud.tar.bz2 -C /var/www/html --strip-components=1; \
     gpgconf --kill all; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    mkdir -p /var/www/html/data \
+        /var/www/html/custom_apps \
+        /var/www/html/config \
+        /var/www/html/themes; \
+    rm -rf /var/www/html/updater; \
+    chown -R www-data:root /var/www/html; \
+    chmod -R ug-w,o= /var/www/html; \
+    chmod ug+x /var/www/html/occ; \
+    chmod ug+w /var/www/html/data \
+        /var/www/html/custom_apps \
+        /var/www/html/config \
+        /var/www/html/themes \
+        /var/www/html/.htaccess \
+        /var/www/html/.user.ini; \
+    \
     apk del .fetch-deps
 
 COPY *.sh /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/* /var/www/html/config/
 
+# Allow the container to be run as random UIDs (for compatibility with OpenShift).
+RUN chgrp root /etc/passwd && chmod g+w /etc/passwd
+
+VOLUME /var/www/html/data \
+    /var/www/html/custom_apps \
+    /var/www/html/config \
+    /var/www/html/themes
+USER www-data:root
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -91,7 +91,6 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
@@ -109,22 +108,40 @@ RUN set -ex; \
     curl -fsSL -o nextcloud.tar.bz2.asc \
         "%%BASE_DOWNLOAD_URL%%/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
-# gpg key from https://nextcloud.com/nextcloud.asc
+    # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    tar -xjf nextcloud.tar.bz2 -C /var/www/html --strip-components=1; \
     gpgconf --kill all; \
     rm -r "$GNUPGHOME" nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    mkdir -p /var/www/html/data \
+        /var/www/html/custom_apps \
+        /var/www/html/config \
+        /var/www/html/themes; \
+    rm -rf /var/www/html/updater; \
+    chown -R www-data:root /var/www/html; \
+    chmod -R ug-w,o= /var/www/html; \
+    chmod ug+x /var/www/html/occ; \
+    chmod ug+w /var/www/html/data \
+        /var/www/html/custom_apps \
+        /var/www/html/config \
+        /var/www/html/themes \
+        /var/www/html/.htaccess \
+        /var/www/html/.user.ini; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
 
 COPY *.sh /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/* /var/www/html/config/
 
+# Allow the container to be run as random UIDs (for compatibility with OpenShift).
+RUN chgrp root /etc/passwd && chmod g+w /etc/passwd
+
+VOLUME /var/www/html/data \
+    /var/www/html/custom_apps \
+    /var/www/html/config \
+    /var/www/html/themes
+USER www-data:root
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,62 +1,18 @@
 #!/bin/sh
 set -eu
 
-# version_greater A B returns whether A > B
-version_greater() {
-	[ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
-}
+if [ "$(id -u)" = 0 ]; then
+	>&2 echo 'Warning - Running as root is not recommended for security reasons.'
+fi
 
-# return true if specified directory is empty
-directory_empty() {
-    [ -z "$(ls -A "$1/")" ]
-}
-
-run_as() {
-  if [ "$(id -u)" = 0 ]; then
-    su - www-data -s /bin/sh -c "$1"
-  else
-    sh -c "$1"
+if ! id -nu >/dev/null 2>&1; then
+	# If there is no entry for the running user ID in the UNIX password file,
+	# provide an identity for the user
+  if [ -w /etc/passwd ]; then
+		cat /etc/passwd > /tmp/passwd
+    echo "nextcloud:x:$(id -u):0:Nextcloud user:/root:/sbin/nologin" >> /tmp/passwd
+		cat /tmp/passwd > /etc/passwd
+	  rm /tmp/passwd
   fi
-}
-
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
-    # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-    fi
-    if [ "$(id -u)" = 0 ]; then
-      rsync_options="-rlDog --chown www-data:root"
-    else
-      rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
-
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-        fi
-    done
-
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have beed disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-    fi
-fi
-
 exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip;\\\n    sed -i s/80/8080/g /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf;\\\n    chgrp root /var/run/apache2;\\\n    chmod -R g=rwX /var/run/apache2'
 	[fpm]=''
 	[fpm-alpine]=''
 )
@@ -105,7 +105,7 @@ for version in "${versions[@]}"; do
 	if version_greater_or_equal "$version" "$min_version"; then
 
 		for variant in "${variants[@]}"; do
-			
+
 			create_variant "$version" "https:\/\/download.nextcloud.com\/server\/releases"
 		done
 	fi
@@ -124,7 +124,7 @@ for version in "${versions_rc[@]}"; do
 		if ! check_released "$fullversion"; then
 
 			for variant in "${variants[@]}"; do
-			
+
 				create_variant "$version-rc" "https:\/\/download.nextcloud.com\/server\/prereleases"
 			done
 		fi


### PR DESCRIPTION
Auto-upgrade procedure in `docker-entrypoint.sh` is also removed
since it won't be necessary if `/var/www/html` is not a volume.