### PR TITLE
Bugfix: MAX_UPLOAD_SIZE is ignored

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
@@ -42,13 +42,12 @@ services:
     ports:
       - 80:80
       - 443:443
-    environment:
-      - MAX_UPLOAD_SIZE=10GB
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
       - html:/usr/share/nginx/html
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./uploadsize.conf:/etc/nginx/conf.d/uploadsize.conf:ro
     networks:
       - proxy-tier
     depends_on:

--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/uploadsize.conf
@@ -1,0 +1,1 @@
+client_max_body_size 10G;


### PR DESCRIPTION
This allows to upload files >1MB for proxy nginx, fixing #371 