### PR TITLE
Remove the "--no-app-disable" option form the "occ upgrade" command

### DIFF
--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0-beta/apache/entrypoint.sh
+++ b/14.0-beta/apache/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0-beta/fpm-alpine/entrypoint.sh
+++ b/14.0-beta/fpm-alpine/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0-beta/fpm/entrypoint.sh
+++ b/14.0-beta/fpm/entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,7 +50,7 @@ if version_greater "$image_version" "$installed_version"; then
     done
 
     if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ upgrade --no-app-disable'
+        run_as 'php /var/www/html/occ upgrade'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"


### PR DESCRIPTION
This option has been removed in nextcloud 14.
And it was unnecessary before because we are running php 7.x.
See: https://github.com/nextcloud/server/pull/7955