### PR TITLE
example Dockerfiles: remove obsolete jessie backports

### DIFF
--- a/.examples/dockerfiles/full/apache/Dockerfile
+++ b/.examples/dockerfiles/full/apache/Dockerfile
@@ -1,7 +1,6 @@
 FROM nextcloud:apache
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-    && mkdir -p /usr/share/man/man1 \
+RUN mkdir -p /usr/share/man/man1 \
     && apt-get update && apt-get install -y \
         supervisor \
         ffmpeg \

--- a/.examples/dockerfiles/full/fpm/Dockerfile
+++ b/.examples/dockerfiles/full/fpm/Dockerfile
@@ -1,7 +1,6 @@
 FROM nextcloud:fpm
 
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
-    && mkdir -p /usr/share/man/man1 \
+RUN mkdir -p /usr/share/man/man1 \
     && apt-get update && apt-get install -y \
         supervisor \
         ffmpeg \


### PR DESCRIPTION
The docker image already is on stretch, so no backports are needed

 (see #435)