### PR TITLE
Auto update indices on NextCloud update

### DIFF
--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -51,6 +51,7 @@ if version_greater "$image_version" "$installed_version"; then
 
     if [ "$installed_version" != "0.0.0.0" ]; then
         run_as 'php /var/www/html/occ upgrade'
+        run_as 'php /var/www/html/occ db:add-missing-indices'
 
         run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
         echo "The following apps have beed disabled:"


### PR DESCRIPTION
After upgrading my NextCloud Docker from `13.0.6` to `14.0.0` the control panel was showing a warning that my database was missing indices.

Currently the `README.md` states that updating the NextCloud Docker is as easy as pulling the new image and recreating the container, and the upgrade process will start automatically. So I think there are 2 options:

* Automatically add missing indices during the upgrade process (as I've done in this PR)
* Add a note to the `README.md` that you may have to manually add missing indices after upgrading

----

If you're looking for a way to manually add missing indices, just run:

```shell
docker exec -it --user www-data $CONTAINER_NAME bash
./occ db:add-missing-indices
```