### PR TITLE
Allow Referrer-Policy header to be configured

### DIFF
--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -95,14 +95,18 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod rewrite remoteip env headers ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    {\
+     echo PassEnv APACHE_REFERRER_POLICY ;\
+     echo Header set Referrer-Policy "%{APACHE_REFERRER_POLICY}e" "env=APACHE_REFERRER_POLICY" ;\
+    } > /etc/apache2/conf-available/referrerpolicy.conf;\
+    a2enconf remoteip referrerpolicy
 
 ENV NEXTCLOUD_VERSION 12.0.11
 

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -95,14 +95,18 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod rewrite remoteip env headers ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    {\
+     echo PassEnv APACHE_REFERRER_POLICY ;\
+     echo Header set Referrer-Policy "%{APACHE_REFERRER_POLICY}e" "env=APACHE_REFERRER_POLICY" ;\
+    } > /etc/apache2/conf-available/referrerpolicy.conf;\
+    a2enconf remoteip referrerpolicy
 
 ENV NEXTCLOUD_VERSION 13.0.6
 

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -95,14 +95,18 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod rewrite remoteip env headers ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
      echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+    {\
+     echo PassEnv APACHE_REFERRER_POLICY ;\
+     echo Header set Referrer-Policy "%{APACHE_REFERRER_POLICY}e" "env=APACHE_REFERRER_POLICY" ;\
+    } > /etc/apache2/conf-available/referrerpolicy.conf;\
+    a2enconf remoteip referrerpolicy
 
 ENV NEXTCLOUD_VERSION 14.0.0
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ If you want you can set the data directory and table prefix, otherwise default v
 - `NEXTCLOUD_DATA_DIR` (default: _/var/www/html/data_) Configures the data directory where nextcloud stores all files from the users.
 - `NEXTCLOUD_TABLE_PREFIX` (default: _""_) Optional prefix for the tables. Used to be `oc_` in the past
 
+If you want you can set the `Referrer-Policy` header, otherwise the header won't be added to the response.
+
+- `APACHE_REFERRER_POLICY` Sets the value of the `Referrer-Policy` header (`apache` variant only).
+
 
 # Running this image with docker-compose
 The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples what you have to look for.

--- a/update.sh
+++ b/update.sh
@@ -19,7 +19,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+	[apache]='\nRUN a2enmod rewrite remoteip env headers ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    {\\\n     echo PassEnv APACHE_REFERRER_POLICY ;\\\n     echo Header set Referrer-Policy "%{APACHE_REFERRER_POLICY}e" "env=APACHE_REFERRER_POLICY" ;\\\n    } > /etc/apache2/conf-available/referrerpolicy.conf;\\\n    a2enconf remoteip referrerpolicy'
 	[fpm]=''
 	[fpm-alpine]=''
 )


### PR DESCRIPTION
This PR adds the ability to configure the `Referrer-Policy` header using the Docker image by setting an environment variable.

Example:

```shell
docker run -e APACHE_REFERRER_POLICY=no-referrer nextcloud
```

This is needed because I'm now getting the following warning in my NextCloud 14 control panel and there's no clean way of fixing this right now (see nextcloud/server#9122):

> The "Referrer-Policy" HTTP header is not set to "no-referrer", "no-referrer-when-downgrade", "strict-origin" or "strict-origin-when-cross-origin". This can leak referer information. See the W3C Recommendation ↗.

Note that this header will **not** be added to the response if this environment variable is not set, so this is not a breaking change. Without explicitly setting the variable, the security message will still appear.