### PR TITLE
Implement #455: auto-install via occ maintenance:install

### DIFF
--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/12.0/apache/config/autoconfig.php
+++ b/12.0/apache/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/12.0/fpm-alpine/config/autoconfig.php
+++ b/12.0/fpm-alpine/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/12.0/fpm/config/autoconfig.php
+++ b/12.0/fpm/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/apache/config/autoconfig.php
+++ b/13.0/apache/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/fpm-alpine/config/autoconfig.php
+++ b/13.0/fpm-alpine/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/fpm/config/autoconfig.php
+++ b/13.0/fpm/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/apache/config/autoconfig.php
+++ b/14.0/apache/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/fpm-alpine/config/autoconfig.php
+++ b/14.0/fpm-alpine/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/fpm/config/autoconfig.php
+++ b/14.0/fpm/config/autoconfig.php
@@ -26,9 +26,4 @@ if ($autoconfig_enabled) {
     $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX') ?: "";
 
     $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
-
-    if (getenv('NEXTCLOUD_ADMIN_USER') && getenv('NEXTCLOUD_ADMIN_PASSWORD')) {
-        $AUTOCONFIG["adminlogin"] = getenv('NEXTCLOUD_ADMIN_USER');
-        $AUTOCONFIG["adminpass"] = getenv('NEXTCLOUD_ADMIN_PASSWORD');
-    }
 }

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,7 @@ directory_empty() {
 
 run_as() {
     if [ "$(id -u)" = 0 ]; then
-        su - www-data -s /bin/sh -c "$1"
+        su -p www-data -s /bin/sh -c "$1"
     else
         sh -c "$1"
     fi
@@ -55,30 +55,30 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
             echo "New nextcloud instance"
             
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                    install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
-                    install_options="$install_options --database-table-prefix \"\""
+                    install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
                 
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
-                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
-                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
                     echo "starting nexcloud installation"
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
-                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s
                     echo "starting nexcloud installation"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,24 +53,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
-            
+
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
                 if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-                
+
                 if [  -n "${SQLITE_DATABASE+x}" ]; then
                     echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                     echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     echo "waiting 30s for the database to setup"
                     sleep 30s
@@ -78,6 +83,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     run_as "php /var/www/html/occ maintenance:install $install_options"
                 elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                     echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     echo "waiting 10s for the database to setup"
                     sleep 10s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,27 +53,29 @@ if version_greater "$image_version" "$installed_version"; then
     if [ "$installed_version" = "0.0.0.0" ]; then
         echo "New nextcloud instance"
         
-        if [ ! -z ${NEXTCLOUD_ADMIN_USER+x} ] && [ ! -z ${NEXTCLOUD_ADMIN_PASSWORD+x} ]; then
+        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
             install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ ! -z ${NEXTCLOUD_TABLE_PREFIX+x} ]; then
+            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
                 install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+            else
+                install_options="$install_options --database-table-prefix \"\""
             fi
-            if [ ! -z ${NEXTCLOUD_DATA_DIR+x} ]; then
+            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                 install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
             fi
             
-            if [ ! -z ${SQLITE_DATABASE+x} ]; then
+            if [  -n "${SQLITE_DATABASE+x}" ]; then
                 echo "Installing with SQLite database"
                 install_options="$install_options --database-name \"$SQLITE_DATABASE\""
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${MYSQL_DATABASE+x} ] && [ ! -z ${MYSQL_USER+x} ] && [ ! -z ${MYSQL_PASSWORD+x} ] && [ ! -z ${MYSQL_HOST+x} ]; then
+            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                 echo "Installing with MySQL database"
                 install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
                 echo "waiting 30s for the database to setup"
                 sleep 30s
                 echo "starting nexcloud installation"
                 run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ ! -z ${POSTGRES_DB+x} ] && [ ! -z ${POSTGRES_USER+x} ] && [ ! -z ${POSTGRES_PASSWORD+x} ] && [ ! -z ${POSTGRES_HOST+x} ]; then
+            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                 echo "Installing with PostgreSQL database"
                 install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
                 echo "waiting 10s for the database to setup"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,82 +19,84 @@ run_as() {
     fi
 }
 
-installed_version="0.0.0.0"
-if [ -f /var/www/html/version.php ]; then
+if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
     # shellcheck disable=SC2016
-    installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-fi
-# shellcheck disable=SC2016
-image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
 
-if version_greater "$installed_version" "$image_version"; then
-    echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-    exit 1
-fi
-
-if version_greater "$image_version" "$installed_version"; then
-    if [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
     fi
-    if [ "$(id -u)" = 0 ]; then
-        rsync_options="-rlDog --chown www-data:root"
-    else
-        rsync_options="-rlD"
-    fi
-    rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    for dir in config data custom_apps themes; do
-        if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-            rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+    if version_greater "$image_version" "$installed_version"; then
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
         fi
-    done
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude /config/ --exclude /data/ --exclude /custom_apps/ --exclude /themes/ /usr/src/nextcloud/ /var/www/html/
 
-    #install
-    if [ "$installed_version" = "0.0.0.0" ]; then
-        echo "New nextcloud instance"
-        
-        if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-            install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
-            if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
-                install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
-            else
-                install_options="$install_options --database-table-prefix \"\""
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
-            fi
+        done
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
             
-            if [  -n "${SQLITE_DATABASE+x}" ]; then
-                echo "Installing with SQLite database"
-                install_options="$install_options --database-name \"$SQLITE_DATABASE\""
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                echo "Installing with MySQL database"
-                install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
-                echo "waiting 30s for the database to setup"
-                sleep 30s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                echo "Installing with PostgreSQL database"
-                install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
-                echo "waiting 10s for the database to setup"
-                sleep 10s
-                echo "starting nexcloud installation"
-                run_as "php /var/www/html/occ maintenance:install $install_options"
-            else
-                echo "running web-based installer on first connect!"
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                install_options="-n --admin-user \"$NEXTCLOUD_ADMIN_USER\" --admin-pass \"$NEXTCLOUD_ADMIN_PASSWORD\""
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                    install_options="$install_options --database-table-prefix \"$NEXTCLOUD_TABLE_PREFIX\""
+                else
+                    install_options="$install_options --database-table-prefix \"\""
+                fi
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    install_options="$install_options --data-dir \"$NEXTCLOUD_DATA_DIR\""
+                fi
+                
+                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    install_options="$install_options --database-name \"$SQLITE_DATABASE\""
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    install_options="$install_options --database mysql --database-name \"$MYSQL_DATABASE\" --database-user \"$MYSQL_USER\" --database-pass \"$MYSQL_PASSWORD\" --database-host \"$MYSQL_HOST\""
+                    echo "waiting 30s for the database to setup"
+                    sleep 30s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    install_options="$install_options --database pgsql --database-name \"$POSTGRES_DB\" --database-user \"$POSTGRES_USER\" --database-pass \"$POSTGRES_PASSWORD\" --database-host \"$POSTGRES_HOST\""
+                    echo "waiting 10s for the database to setup"
+                    sleep 10s
+                    echo "starting nexcloud installation"
+                    run_as "php /var/www/html/occ maintenance:install $install_options"
+                else
+                    echo "running web-based installer on first connect!"
+                fi
             fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
-    #upgrade
-    else
-        run_as 'php /var/www/html/occ upgrade'
-
-        run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-        echo "The following apps have been disabled:"
-        diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-        rm -f /tmp/list_before /tmp/list_after
-
     fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache*" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016


### PR DESCRIPTION
Resolves #455 
Closes #180

For now I tested it locally with the following docker-compose script (on the same level as the repository):

```yaml
version: "3"

services:
  app-sqlite:
    image: nextcloud-test
    build: docker/14.0/apache
    environment:
      - SQLITE_DATABASE=nextcloud
      - NEXTCLOUD_ADMIN_USER=admin
      - NEXTCLOUD_ADMIN_PASSWORD=pw
    ports:
      - "8080:80"

  mysql:
    image: mariadb
    environment:
      - MYSQL_ROOT_PASSWORD=abc
      - MYSQL_DATABASE=nextcloud
      - MYSQL_USER=nextcloud
      - MYSQL_PASSWORD=12345
  app-mysql:
    image: nextcloud-test
    build: docker/14.0/apache
    environment:
      - MYSQL_HOST=mysql
      - MYSQL_DATABASE=nextcloud
      - MYSQL_USER=nextcloud
      - MYSQL_PASSWORD=12345
      - NEXTCLOUD_ADMIN_USER=admin
      - NEXTCLOUD_ADMIN_PASSWORD=pw
    ports:
      - "8081:80"
    depends_on:
      - mysql
      
  postgre:
    image: postgres
    environment: 
      - POSTGRES_PASSWORD=123
      - POSTGRES_DB=lettheinstallcreatethedatabase
      - POSTGRES_USER=nextcloud
  app-postgre:
    image: nextcloud-test
    build: docker/14.0/apache
    environment:
      - POSTGRES_HOST=postgre
      - POSTGRES_PASSWORD=123
      - POSTGRES_DB=nextcloud
      - POSTGRES_USER=nextcloud
      - NEXTCLOUD_ADMIN_USER=admin
      - NEXTCLOUD_ADMIN_PASSWORD=pw
    ports:
      - "8082:80"
    depends_on:
      - postgre
```

I just added a `sleep` for postgre and mysql because otherwise install will fail as long as the database is not finished with it's setup procedure.