### PR TITLE
[WIP] Install smbclient dependencies to enable SMB/CIFS External storage

### DIFF
--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -114,7 +114,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -106,7 +106,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -114,7 +114,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -106,7 +106,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -114,7 +114,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -106,7 +106,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -105,7 +105,7 @@ RUN set -ex; \
         dirmngr \
     "; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $fetchDeps; \
+    apt-get install -y --no-install-recommends $fetchDeps smbclient; \
     \
     curl -fsSL -o nextcloud.tar.bz2 \
         "%%BASE_DOWNLOAD_URL%%/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \


### PR DESCRIPTION
I've simply added `smbclient` as a dependency to each `Dockerfile` (using the templates, of course), to allow SMB/CIFS shares to be used under the `External Storage` configuration.