### PR TITLE
Default data dir v1

### DIFF
--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -35,7 +35,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -35,7 +35,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     depends_on:
       - app
 
@@ -43,7 +43,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -30,7 +30,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     depends_on:
       - app
 

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - POSTGRES_HOST=db
     env_file:

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - POSTGRES_HOST=db
     env_file:
@@ -27,7 +27,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     depends_on:
       - app
 

--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -28,7 +28,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     environment:
       - VIRTUAL_HOST=
     depends_on:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -39,7 +39,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -33,7 +33,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -48,7 +48,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -28,7 +28,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud:/var/www
     environment:
       - POSTGRES_HOST=db
     env_file:
@@ -25,7 +25,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud:/var/www:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=

--- a/12.0-rc/apache/Dockerfile
+++ b/12.0-rc/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/12.0-rc/apache/entrypoint.sh
+++ b/12.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/12.0-rc/fpm-alpine/Dockerfile
+++ b/12.0-rc/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 12.0.12RC1

--- a/12.0-rc/fpm-alpine/entrypoint.sh
+++ b/12.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/12.0-rc/fpm/Dockerfile
+++ b/12.0-rc/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 12.0.12RC1

--- a/12.0-rc/fpm/entrypoint.sh
+++ b/12.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 12.0.11

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 12.0.11

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0-rc/apache/Dockerfile
+++ b/13.0-rc/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/13.0-rc/apache/entrypoint.sh
+++ b/13.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0-rc/fpm-alpine/Dockerfile
+++ b/13.0-rc/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 13.0.7RC1

--- a/13.0-rc/fpm-alpine/entrypoint.sh
+++ b/13.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0-rc/fpm/Dockerfile
+++ b/13.0-rc/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 13.0.7RC1

--- a/13.0-rc/fpm/entrypoint.sh
+++ b/13.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 13.0.6

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 13.0.6

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0-rc/apache/Dockerfile
+++ b/14.0-rc/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/14.0-rc/apache/entrypoint.sh
+++ b/14.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0-rc/fpm-alpine/Dockerfile
+++ b/14.0-rc/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 14.0.2RC1

--- a/14.0-rc/fpm-alpine/entrypoint.sh
+++ b/14.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0-rc/fpm/Dockerfile
+++ b/14.0-rc/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 14.0.2RC1

--- a/14.0-rc/fpm/entrypoint.sh
+++ b/14.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0/fpm-alpine/Dockerfile
+++ b/14.0/fpm-alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 14.0.1

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -95,7 +95,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 
 
 ENV NEXTCLOUD_VERSION 14.0.1

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -83,7 +83,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -94,7 +94,7 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/www/data"'
                 fi
 
                 install=false


### PR DESCRIPTION
I have two improvement proposals and this is v1. Please read v2 as well. 

The admin manual recommends to place the data directory outside the web root as noted in [this post](https://help.nextcloud.com/t/admin-manual-recommends-placing-data-directory-outside-web-root-why/22225). Such a directory was created in pull request #307, but is never used. 

This pull request defaults the data directory on install to the folder in #307, which requires the created volume to be mounted already at /var/www to make sure nothing is lost. 

This requires only one volume but does not entirely solve the web root issue. Furthermore, mounting the entire /var/www folder might cause compatibility trouble for users running multiple docker services behind one nginx proxy.

The v2 solutions handles it with two volumes, but is a bit messier. 