### PR TITLE
Default data dir

### DIFF
--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -44,5 +44,5 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -43,4 +44,5 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -36,7 +36,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     depends_on:
       - app
 
@@ -44,7 +44,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
@@ -53,5 +53,5 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -35,7 +36,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     depends_on:
       - app
 
@@ -43,7 +44,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
       - db
@@ -51,4 +53,5 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -29,5 +29,5 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -18,7 +18,8 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -28,4 +29,5 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -31,11 +31,11 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     depends_on:
       - app
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -30,10 +31,11 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     depends_on:
       - app
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
@@ -26,5 +26,5 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
     env_file:
@@ -25,4 +26,5 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
     env_file:
@@ -27,10 +28,11 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     depends_on:
       - app
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
@@ -28,11 +28,11 @@ services:
     ports:
       - 8080:80
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     depends_on:
       - app
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:

--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -29,7 +29,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
     depends_on:
@@ -70,7 +70,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -28,7 +29,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
     depends_on:
@@ -69,7 +70,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
@@ -40,7 +40,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
@@ -78,7 +78,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -39,7 +40,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
       - db
@@ -76,7 +78,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -33,7 +34,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -48,7 +49,8 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
       - db
@@ -85,7 +87,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -34,7 +34,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -49,7 +49,7 @@ services:
     build: ./app
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     entrypoint: /cron.sh
     depends_on:
@@ -87,7 +87,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
@@ -62,7 +62,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -61,7 +62,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
@@ -29,7 +29,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -71,7 +71,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - MYSQL_HOST=db
     env_file:
@@ -28,7 +29,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -70,7 +71,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -58,7 +59,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:apache
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - VIRTUAL_HOST=
@@ -59,7 +59,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html
+      - nextcloud:/var/www/html
       - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
@@ -26,7 +26,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud_html:/var/www/html:ro
+      - nextcloud:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -68,7 +68,7 @@ services:
 
 volumes:
   db:
-  nextcloud_html:
+  nextcloud:
   nextcloud_data:
   certs:
   vhost.d:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     image: nextcloud:fpm
     restart: always
     volumes:
-      - nextcloud:/var/www/html
+      - nextcloud_html:/var/www/html
+      - nextcloud_data:/var/nc_data
     environment:
       - POSTGRES_HOST=db
     env_file:
@@ -25,7 +26,7 @@ services:
     build: ./web
     restart: always
     volumes:
-      - nextcloud:/var/www/html:ro
+      - nextcloud_html:/var/www/html:ro
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -67,7 +68,8 @@ services:
 
 volumes:
   db:
-  nextcloud:
+  nextcloud_html:
+  nextcloud_data:
   certs:
   vhost.d:
   html:

--- a/12.0-rc/apache/Dockerfile
+++ b/12.0-rc/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/12.0-rc/apache/entrypoint.sh
+++ b/12.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/12.0-rc/fpm-alpine/Dockerfile
+++ b/12.0-rc/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 12.0.12RC1

--- a/12.0-rc/fpm-alpine/entrypoint.sh
+++ b/12.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/12.0-rc/fpm/Dockerfile
+++ b/12.0-rc/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 12.0.12RC1

--- a/12.0-rc/fpm/entrypoint.sh
+++ b/12.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/12.0/apache/Dockerfile
+++ b/12.0/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/12.0/fpm-alpine/Dockerfile
+++ b/12.0/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 12.0.11

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/12.0/fpm/Dockerfile
+++ b/12.0/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 12.0.11

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0-rc/apache/Dockerfile
+++ b/13.0-rc/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/13.0-rc/apache/entrypoint.sh
+++ b/13.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0-rc/fpm-alpine/Dockerfile
+++ b/13.0-rc/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 13.0.7RC1

--- a/13.0-rc/fpm-alpine/entrypoint.sh
+++ b/13.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0-rc/fpm/Dockerfile
+++ b/13.0-rc/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 13.0.7RC1

--- a/13.0-rc/fpm/entrypoint.sh
+++ b/13.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 13.0.6

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 13.0.6

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0-rc/apache/Dockerfile
+++ b/14.0-rc/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/14.0-rc/apache/entrypoint.sh
+++ b/14.0-rc/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0-rc/fpm-alpine/Dockerfile
+++ b/14.0-rc/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 14.0.2RC1

--- a/14.0-rc/fpm-alpine/entrypoint.sh
+++ b/14.0-rc/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0-rc/fpm/Dockerfile
+++ b/14.0-rc/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 14.0.2RC1

--- a/14.0-rc/fpm/entrypoint.sh
+++ b/14.0-rc/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 RUN a2enmod rewrite remoteip ;\
     {\

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0/fpm-alpine/Dockerfile
+++ b/14.0/fpm-alpine/Dockerfile
@@ -80,11 +80,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 14.0.1

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -91,11 +91,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 
 
 ENV NEXTCLOUD_VERSION 14.0.1

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -79,11 +79,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -90,11 +90,12 @@ RUN { \
     \
     echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
     \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    mkdir /var/nc_data; \
+    chown -R www-data:root /var/www /var/nc_data; \
+    chmod -R g=u /var/www /var/nc_data
 
 VOLUME /var/www/html
+VOLUME /var/nc_data
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,6 +69,8 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                 if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                else
+                    install_options=$install_options' --data-dir "/var/nc_data"'
                 fi
 
                 install=false


### PR DESCRIPTION
The admin manual recommends to place the data directory outside the web root as noted in [this post](https://help.nextcloud.com/t/admin-manual-recommends-placing-data-directory-outside-web-root-why/22225). Such a directory was created in pull request #307, but is never used. 

This pull request defaults the data directory on install to the folder /var/nc_data which is  outside the webroot. 

However, this requires two volume mounts to provide persistence for both the html code and the user's data. This is a bit messier as can be seen in the updated docker-compose examples. 