### PR TITLE
add a mechanism to set trusted domains on install

### DIFF
--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ If you want you can set the data directory and table prefix, otherwise default v
 - `NEXTCLOUD_DATA_DIR` (default: _/var/www/html/data_) Configures the data directory where nextcloud stores all files from the users.
 - `NEXTCLOUD_TABLE_PREFIX` (default: _""_) Optional prefix for the tables. Used to be `oc_` in the past
 
+One or more trusted domains can be set by environemnt variable, too. They will be added to the configuration after install.
+
+- `NEXTCLOUD_TRUSTED_DOMAINS` (not set by default) Optional space-separated list of domains
 
 # Running this image with docker-compose
 The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples what you have to look for.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -88,7 +88,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                     install=true
                 fi
-                
+
                 if [ "$install" = true ]; then
                     echo "starting nexcloud installation"
                     max_retries=10
@@ -102,6 +102,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
                     if [ "$try" -gt "$max_retries" ]; then
                         echo "installing of nextcloud failed!"
                         exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
                     fi
                 else
                     echo "running web-based installer on first connect!"


### PR DESCRIPTION
Resolves #469 

Optionally, `NEXTCLOUD_TRUSTED_DOMAINS` can be specified. After sucessfull install, occ is being used to set the provided domains names. 

for example:

```
$ sudo docker run -e SQLITE_DATABASE=foobar -e NEXTCLOUD_ADMIN_USER=adm -e NEXTCLOUD_ADMIN_PASSWORD=dma -e NEXTCLOUD_TRUSTED_DOMAINS=foo.bar\ barfoo.com f7469ede5323
Initializing nextcloud 14.0.2.2 ...
Initializing finished
New nextcloud instance
Installing with SQLite database
starting nexcloud installation
creating sqlite db
Nextcloud was successfully installed
setting trusted domains…
System config value trusted_domains => 1 set to string foo.bar
System config value trusted_domains => 2 set to string barfoo.com
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
[Fri Oct 12 12:46:54.210310 2018] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.25 (Debian) PHP/7.2.10 configured -- resuming normal operations
[Fri Oct 12 12:46:54.210354 2018] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
```

```
$ sudo docker exec -it c0cfa5a94c19 /bin/bash
root@c0cfa5a94c19:/var/www/html# cat config/config.php 
<?php
$CONFIG = array (
…
  'trusted_domains' => 
  array (
    0 => 'localhost',
    1 => 'foo.bar',
    2 => 'barfoo.com',
  ),
…
);
```