### PR TITLE
run upgrades when using supervisord

### DIFF
--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ run_as() {
     fi
 }
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
+if expr "$1" :  '.*\(apache\|php-fpm\|supervisord\)' 1>/dev/null; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then
         # shellcheck disable=SC2016


### PR DESCRIPTION
All of the `cron` and `full` examples in `.examples` run `supervisord` as the command.

Also, not sure if this is an issue, but using `|` with `expr` is a GNU extension. The test seems to run fine on alpine linux