### PR TITLE
Update with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
   db:
-    image: mariadb
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    image: mariadb:10.3
+    command: --transaction-isolation=READ-COMMITTED --log-bin=mysqld-bin --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
    Changed version to 10.3 because: #503
    Added "--log-bin=mysqld-bin" caused of startup Warning.