### PR TITLE
Change set criteria for environment variables

### DIFF
--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,29 +60,29 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_TABLE_PREFIX+x}" ]; then
+                if [ -n "${NEXTCLOUD_TABLE_PREFIX}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-table-prefix "$NEXTCLOUD_TABLE_PREFIX"'
                 else
                     install_options=$install_options' --database-table-prefix ""'
                 fi
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                if [ -n "${NEXTCLOUD_DATA_DIR}" ]; then
                     # shellcheck disable=SC2016
                     install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
 
                 install=false
-                if [  -n "${SQLITE_DATABASE+x}" ]; then
+                if [  -n "${SQLITE_DATABASE}" ]; then
                     echo "Installing with SQLite database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database-name "$SQLITE_DATABASE"'
                     install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                elif [ -n "${MYSQL_DATABASE}" ] && [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_PASSWORD}" ] && [ -n "${MYSQL_HOST}" ]; then
                     echo "Installing with MySQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                     install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                elif [ -n "${POSTGRES_DB}" ] && [ -n "${POSTGRES_USER}" ] && [ -n "${POSTGRES_PASSWORD}" ] && [ -n "${POSTGRES_HOST}" ]; then
                     echo "Installing with PostgreSQL database"
                     # shellcheck disable=SC2016
                     install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
@@ -103,7 +103,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "installing of nextcloud failed!"
                         exit 1
                     fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS}" ]; then
                         echo "setting trusted domains…"
                         NC_TRUSTED_DOMAIN_IDX=1
                         for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do


### PR DESCRIPTION
Appending "+x" to the environment variables, in these cases, allows them to bet set to empty strings.
The if-statements here would then return true for empty variables ([examples](https://serverfault.com/a/382740)) which does not make sense at the places I changed them. 