### PR TITLE
Set Redis via environment vars

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/12.0/apache/config/redis.config.php
+++ b/12.0/apache/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/12.0/fpm-alpine/config/redis.config.php
+++ b/12.0/fpm-alpine/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/12.0/fpm/config/redis.config.php
+++ b/12.0/fpm/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/13.0/apache/config/redis.config.php
+++ b/13.0/apache/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/13.0/fpm-alpine/config/redis.config.php
+++ b/13.0/fpm-alpine/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/13.0/fpm/config/redis.config.php
+++ b/13.0/fpm/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/14.0/apache/config/redis.config.php
+++ b/14.0/apache/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/14.0/fpm-alpine/config/redis.config.php
+++ b/14.0/fpm-alpine/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/14.0/fpm/config/redis.config.php
+++ b/14.0/fpm/config/redis.config.php
@@ -1,0 +1,11 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'port' => getenv('REDIS_PORT') ?: 6379,
+    ),
+  );
+}
+

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ The install and update script is only triggered when a default command is used (
 
 - `NEXTCLOUD_UPDATE` (default: _0_)
 
+If you want to use Redis you have to create a seperate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker-compose file. To inform Nextcloud about the Redis container add:
+
+- 'REDIS_HOST' (not set by default) Name of Redis container
+- 'REDIS_PORT' (optional, default:_6379_) Port number of Redis container. Use only if you use a non-standard port.
 
 
 # Running this image with docker-compose


### PR DESCRIPTION
Copy of the Redis part of #292 without the SMTP part. Redis has to be set at boot time, SMTP can be set through the Nextcloud webinterface. Tested with Apache / 14.0.3.

New PR after running update.sh

@rodrigoaguilera @unteem