### PR TITLE
Launch crond in background from entrypoint.sh

### DIFF
--- a/12.0/apache/cron.sh
+++ b/12.0/apache/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/12.0/apache/entrypoint.sh
+++ b/12.0/apache/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/12.0/fpm-alpine/cron.sh
+++ b/12.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/12.0/fpm-alpine/entrypoint.sh
+++ b/12.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/12.0/fpm/cron.sh
+++ b/12.0/fpm/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/12.0/fpm/entrypoint.sh
+++ b/12.0/fpm/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/13.0/apache/cron.sh
+++ b/13.0/apache/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/13.0/fpm-alpine/cron.sh
+++ b/13.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/13.0/fpm/cron.sh
+++ b/13.0/fpm/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/14.0/apache/cron.sh
+++ b/14.0/apache/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/14.0/fpm-alpine/cron.sh
+++ b/14.0/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/14.0/fpm/cron.sh
+++ b/14.0/fpm/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/15.0-beta/apache/cron.sh
+++ b/15.0-beta/apache/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/15.0-beta/apache/entrypoint.sh
+++ b/15.0-beta/apache/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/15.0-beta/fpm-alpine/cron.sh
+++ b/15.0-beta/fpm-alpine/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/15.0-beta/fpm-alpine/entrypoint.sh
+++ b/15.0-beta/fpm-alpine/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/15.0-beta/fpm/cron.sh
+++ b/15.0-beta/fpm/cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/15.0-beta/fpm/entrypoint.sh
+++ b/15.0-beta/fpm/entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"

--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -b -l 0 -L /dev/stdout

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -129,4 +129,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+/cron.sh
+
 exec "$@"


### PR DESCRIPTION
This is so that the crontab is executed on a regular schedule in the background
without a secondary container to execute it.

Relates to #134