### PR TITLE
Match image version with corresponding Server Administration Manual

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -11,7 +11,7 @@ RUN set -ex; \
     echo '*/15 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
 # install the PHP extensions we need
-# see https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html
+# see https://docs.nextcloud.com/server/%%DOCS_VERSION%%/admin_manual/installation/source_installation.html
 RUN set -ex; \
     \
     apk add --no-cache --virtual .build-deps \
@@ -64,7 +64,7 @@ RUN set -ex; \
     apk del .build-deps
 
 # set recommended PHP.ini settings
-# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+# see https://docs.nextcloud.com/server/%%DOCS_VERSION%%/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 RUN { \
         echo 'opcache.enable=1'; \
         echo 'opcache.enable_cli=1'; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -15,7 +15,7 @@ RUN set -ex; \
     echo '*/15 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
 # install the PHP extensions we need
-# see https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html
+# see https://docs.nextcloud.com/server/%%DOCS_VERSION%%/admin_manual/installation/source_installation.html
 RUN set -ex; \
     \
     savedAptMark="$(apt-mark showmanual)"; \
@@ -75,7 +75,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
-# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+# see https://docs.nextcloud.com/server/%%DOCS_VERSION%%/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 RUN { \
         echo 'opcache.enable=1'; \
         echo 'opcache.enable_cli=1'; \

--- a/update.sh
+++ b/update.sh
@@ -78,6 +78,7 @@ function create_variant() {
 		s/%%APCU_VERSION%%/'"${pecl_versions[APCu]}"'/g;
 		s/%%MEMCACHED_VERSION%%/'"${pecl_versions[memcached]}"'/g;
 		s/%%REDIS_VERSION%%/'"${pecl_versions[redis]}"'/g;
+                s/%%DOCS_VERSION%%/'"${1%.*}"'/g;
 	' "$dir/Dockerfile"
 
 	# Copy the shell scripts


### PR DESCRIPTION
Currently all `Dockerfile`s refer to Server Administration Manual version 12. This patch allows to base this version on specific image version.