### PR TITLE
Add procps to be installed in 

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -5,6 +5,7 @@ RUN set -ex; \
     \
     apk add --no-cache \
         rsync \
+        procps \
     ; \
     \
     rm /var/spool/cron/crontabs/root; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,6 +8,7 @@ RUN set -ex; \
         rsync \
         bzip2 \
         busybox-static \
+        procps \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \


### PR DESCRIPTION
Reviewing logs while browsing SMB external storage(s) show many instances of:
```Example: [28-Nov-2018 19:41:23] WARNING: [pool www] child 2243 said into stderr: "sh: 1: ps: not found"```

Added procps to Dockerfile.*.template to address this.

Please advise if more appropriate method is available.