### PR TITLE
Configure PHP memory_limit via environment variable

### DIFF
--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/13.0/fpm-alpine/Dockerfile
+++ b/13.0/fpm-alpine/Dockerfile
@@ -78,11 +78,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/14.0/fpm-alpine/Dockerfile
+++ b/14.0/fpm-alpine/Dockerfile
@@ -78,11 +78,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/15.0/fpm-alpine/Dockerfile
+++ b/15.0/fpm-alpine/Dockerfile
@@ -78,11 +78,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/15.0/fpm/Dockerfile
+++ b/15.0/fpm/Dockerfile
@@ -89,11 +89,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -77,11 +77,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 %%VARIANT_EXTRAS%%

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -88,11 +88,16 @@ RUN { \
     \
     echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
-    \
     mkdir /var/www/data; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
+
+# Allow PHP memory_limit to be configurable. Touch the INI file and give open permissions so that
+# the entrypoint script can modify it when the container is run by non-root users.
+ENV PHP_MEMORY_LIMIT=512M
+RUN true \
+    && ini_file=/usr/local/etc/php/conf.d/memory-limit.ini \
+    && touch "$ini_file" && chmod a+rw "$ini_file"
 
 VOLUME /var/www/html
 %%VARIANT_EXTRAS%%

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ The install and update script is only triggered when a default command is used (
 
 - `NEXTCLOUD_UPDATE` (default: _0_)
 
+The PHP `memory_limit` setting can be controlled by specifying the below environment variable.
 
+- `PHP_MEMORY_LIMIT` (default: `512M`)
 
 # Running this image with docker-compose
 The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples what you have to look for.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,9 @@ run_as() {
     fi
 }
 
+# Update PHP's memory limit based on environment variable specified to Docker
+echo "memory_limit=$PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
     if [ -f /var/www/html/version.php ]; then


### PR DESCRIPTION
A new Docker environment variable named `PHP_MEMORY_LIMIT` has been introduced
which allows the PHP `memory_limit` setting to be controlled without mounting
any volumes from the host. The default memory limit is still `512M` if this
variable is not specified.

Tested on 14.0 apache. 
