### PR TITLE
Fix typo in docker-entrypoint.sh

### DIFF
--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nexcloud installation"
+                    echo "starting nextcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]


### PR DESCRIPTION
A little typo I saw the other day while setting up my nextcloud server.