### PR TITLE
Add db command to docker-compose example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ volumes:
 services:
   db:
     image: mariadb
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql
@@ -192,6 +193,7 @@ volumes:
 services:
   db:
     image: mariadb
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
Another small thing I noticed: MariaDB should be setup with the right transaction isolation level and binlog format. This has already been done in the docker-compose examples, but not on the front page readme.

More information is available in the [nextcloud server documentation](https://docs.nextcloud.com/server/14/admin_manual/configuration_database/linux_database_configuration.html#configuring-a-mysql-or-mariadb-database).