### PR TITLE
Fix woff2 files in nginx examples

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
@@ -125,7 +125,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
@@ -125,7 +125,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -125,7 +125,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -125,7 +125,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to


### PR DESCRIPTION
Since some versions of Nextcloud, fonts are served as woff2, which is not forwarded to index.php by the supplied nginx.conf. This leads to nginx returning the dynamic index page instead of the static fonts.

See https://docs.nextcloud.com/server/15/admin_manual/installation/nginx.html