### PR TITLE
fix version check without volume var/www/html

### DIFF
--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,11 @@ version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
 }
 
+# version_equal A B returns whether A = B
+version_equal() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" = "$1" ]
+}
+
 # return true if specified directory is empty
 directory_empty() {
     [ -z "$(ls -A "$1/")" ]
@@ -21,9 +26,9 @@ run_as() {
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
+    if [ -f /var/www/html/config/config.php ]; then
         # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        installed_version="$(awk '$1 ~ /version/ { print $3 }' /var/www/html/config/config.php | grep -oP "(?<=').*(?=')")"
     fi
     # shellcheck disable=SC2016
     image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
@@ -31,6 +36,22 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     if version_greater "$installed_version" "$image_version"; then
         echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
         exit 1
+    fi
+
+    if version_equal "$installed_version" "$image_version"; then
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        echo "Initializing finished"
     fi
 
     if version_greater "$image_version" "$installed_version"; then
@@ -90,7 +111,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 fi
 
                 if [ "$install" = true ]; then
-                    echo "starting nextcloud installation"
+                    echo "starting nexcloud installation"
                     max_retries=10
                     try=0
                     until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]


### PR DESCRIPTION
it fixes https://github.com/nextcloud/docker/issues/489
At the moment the upgrade does not work if there is no volume for `/var/www/html/` as it checks `/var/www/html/version.php` to compare versions. This PR make it so it checks for the version in `var/www/html/config` which must be persisted and everyone is happy :)