### PR TITLE
create Apache SSL self signed certificates with environment variable

### DIFF
--- a/.config/000-default.conf
+++ b/.config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/.config/000-default.conf
+++ b/.config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -138,9 +138,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/13.0/apache/Dockerfile
+++ b/13.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/13.0/apache/config/000-default.conf
+++ b/13.0/apache/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/13.0/apache/config/000-default.conf
+++ b/13.0/apache/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/apache/entrypoint.sh
+++ b/13.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm-alpine/config/000-default.conf
+++ b/13.0/fpm-alpine/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/13.0/fpm-alpine/config/000-default.conf
+++ b/13.0/fpm-alpine/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm-alpine/entrypoint.sh
+++ b/13.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/13.0/fpm/Dockerfile
+++ b/13.0/fpm/Dockerfile
@@ -130,9 +130,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/13.0/fpm/config/000-default.conf
+++ b/13.0/fpm/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/13.0/fpm/config/000-default.conf
+++ b/13.0/fpm/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/13.0/fpm/entrypoint.sh
+++ b/13.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -138,9 +138,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/14.0/apache/config/000-default.conf
+++ b/14.0/apache/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/14.0/apache/config/000-default.conf
+++ b/14.0/apache/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/apache/entrypoint.sh
+++ b/14.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm-alpine/config/000-default.conf
+++ b/14.0/fpm-alpine/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/14.0/fpm-alpine/config/000-default.conf
+++ b/14.0/fpm-alpine/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm-alpine/entrypoint.sh
+++ b/14.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -130,9 +130,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/14.0/fpm/config/000-default.conf
+++ b/14.0/fpm/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/14.0/fpm/config/000-default.conf
+++ b/14.0/fpm/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/14.0/fpm/entrypoint.sh
+++ b/14.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -138,9 +138,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -137,7 +137,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/15.0/apache/config/000-default.conf
+++ b/15.0/apache/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/15.0/apache/config/000-default.conf
+++ b/15.0/apache/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/apache/entrypoint.sh
+++ b/15.0/apache/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm-alpine/config/000-default.conf
+++ b/15.0/fpm-alpine/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/15.0/fpm-alpine/config/000-default.conf
+++ b/15.0/fpm-alpine/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm-alpine/entrypoint.sh
+++ b/15.0/fpm-alpine/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm/Dockerfile
+++ b/15.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/15.0/fpm/Dockerfile
+++ b/15.0/fpm/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/15.0/fpm/Dockerfile
+++ b/15.0/fpm/Dockerfile
@@ -130,9 +130,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/15.0/fpm/config/000-default.conf
+++ b/15.0/fpm/config/000-default.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+   Redirect / https://${SERVER_NAME}
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/ca.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/ca.key
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
+</VirtualHost>
+

--- a/15.0/fpm/config/000-default.conf
+++ b/15.0/fpm/config/000-default.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
-   Redirect / https://${SERVER_NAME}
+    RewriteEngine on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*; \
     \
     mkdir -p /usr/src/apache
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -129,7 +129,7 @@ RUN set -ex; \
     chmod +x /usr/src/nextcloud/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
     \
     mkdir -p /usr/src/apache
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -130,9 +130,12 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     rm -rf /var/lib/apt/lists/*
+    \
+    mkdir -p /usr/src/apache
 
 COPY *.sh upgrade.exclude /
-COPY config/* /usr/src/nextcloud/config/
+COPY config/*.php /usr/src/nextcloud/config/
+COPY config/000-default.conf /usr/src/apache/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,8 @@ fi
 echo "net voor de loop"
 
 
-if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
+if [ ! "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,10 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" = "apache" ]; then
+echo "net voor de loop"
+echo expr "$1"
+
+if expr "$1" : "apache" ; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -133,7 +133,8 @@ fi
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+
+if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -129,4 +129,16 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+## APACHE SSL
+## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+  a2enmod ssl
+  a2enmod headers
+  openssl genrsa -out ca.key 2048
+  openssl req -batch -nodes -new -key ca.key -out ca.csr
+  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+  mkdir -p /etc/apache2/ssl
+  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+## einde SSL toevoegingen
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,11 +132,9 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
-echo expr "$1"
 
-if expr "$1" : "apache" ; then
+if expr "$1" : "apache" || [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   echo "in de apache loop"	
-  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,9 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
+if [ expr "$1" : "apache" 1]; then
+  echo "in de apache loop"	
+  #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,11 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-echo "net voor de loop"
-
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-# if [ -d "/etc/apache2" ]; then
-  echo "in de apache loop"	
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -d "/etc/apache2" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,15 +130,17 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
-  a2enmod ssl
-  a2enmod headers
-  openssl genrsa -out ca.key 2048
-  openssl req -batch -nodes -new -key ca.key -out ca.csr
-  openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
-  mkdir -p /etc/apache2/ssl
-  mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" ]; then
+  if [ "${APACHE_SSL_SELFSIGNED}" = "true" ]; then
+    a2enmod ssl
+    a2enmod headers
+    openssl genrsa -out ca.key 2048
+    openssl req -batch -nodes -new -key ca.key -out ca.csr
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
+    mkdir -p /etc/apache2/ssl
+    mv ca.crt ca.key ca.csr /etc/apache2/ssl/
+    mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
+  fi
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,12 +130,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-## ENV VAR set dan dit uitvoeren nog inbouwen
 echo "net voor de loop"
 
-
-# if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2" ]; then
+if [ -n "${APACHE_SSL_SELFSIGNED+x}" "true" ] ; then
+# if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] || [ -f "/etc/apache2/sites-enabled/000-default.conf" ]; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" 1]; then
+if [ expr "$1" : "apache" : 1]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -129,8 +129,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
-## APACHE SSL
-## als APACHE en ENV VAR set dan dit uitvoeren nog inbouwen
+## APACHE SSL configuration (self signed certificates)
+## ENV VAR set dan dit uitvoeren nog inbouwen
+if expr "$1" : "apache" 1 || [-n "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048
@@ -139,6 +140,6 @@ fi
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
   mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
-## einde SSL toevoegingen
+fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,7 +130,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 fi
 
 ## APACHE SSL configuration (self signed certificates)
-if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/apache/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if [ expr "$1" : "apache" : 1]; then
+if [ expr "$1" = "apache" ]; then
   echo "in de apache loop"	
   #	[ "${APACHE_SSL_SELFSIGNED}" "true" ]; then
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ fi
 
 ## APACHE SSL configuration (self signed certificates)
 ## ENV VAR set dan dit uitvoeren nog inbouwen
-if expr "$1" : "apache" 1 || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
+if [ expr "$1" : "apache" 1] || [ "${APACHE_SSL_SELFSIGNED+x}" "true" ]; then
   a2enmod ssl
   a2enmod headers
   openssl genrsa -out ca.key 2048

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,7 +132,7 @@ fi
 ## APACHE SSL configuration (self signed certificates)
 echo "net voor de loop"
 
-if [ -n "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
+if [ "${APACHE_SSL_SELFSIGNED}" = "true" ] ; then
 # if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -138,7 +138,7 @@ fi
   openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt
   mkdir -p /etc/apache2/ssl
   mv ca.crt ca.key ca.csr /etc/apache2/ssl/
-  mv /var/www/html/config/000-default.conf /etc/apache2/sites-enabled/
+  mv /usr/src/nextcloud/config/000-default.conf /etc/apache2/sites-enabled/
 ## einde SSL toevoegingen
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ ! "/etc/apache2"]; then
+if [ -d "/etc/apache2"]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -135,7 +135,7 @@ echo "net voor de loop"
 
 
 # if expr "$1" : "apache" 1>/dev/null && [ -n "${APACHE_SSL_SELFSIGNED+x}" ] ; then
-if [ -d "/etc/apache2"]; then
+if [ -d "/etc/apache2" ]; then
   echo "in de apache loop"	
   a2enmod ssl
   a2enmod headers


### PR DESCRIPTION
PR to enable SSL encryption with self-signed certificates on Apache. Multiple SSL related errors will disappear (.well.know autodiscovery, apps not working). For use behind a proxy or in private environments. For Traefik you need to set insecureSkipVerify: true in the traefik.yaml file so the self signed certificates are not rejected. The SSL encryption is activated by an environment variable to prevent existing installations to break. The certificates will be renewed every time the entrypoint script runs.

Please help with testing on different environments (behind Nginx proxy).

To do: the README and examples have to be rewritten.