### PR TITLE
nginx-proxy: Set proxy_request_buffering to off. Fixes #650

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/uploadsize.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/uploadsize.conf
@@ -1,1 +1,2 @@
 client_max_body_size 10G;
+proxy_request_buffering off;


### PR DESCRIPTION
Otherwise nginx buffers uploads which at least with the linux client results
in large files failing to upload and the upload stats not updating.