### PR TITLE
Fix Remaining `.woff2` Issues in NGinx Config Examples

### DIFF
--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/web/nginx.conf
@@ -120,7 +120,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -120,7 +120,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to

--- a/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
@@ -120,7 +120,7 @@ http {
 
         # Adding the cache control header for js and css files
         # Make sure it is BELOW the PHP block
-        location ~ \.(?:css|js|woff|svg|gif)$ {
+        location ~ \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463";
             # Add headers to serve security related headers (It is intended to


### PR DESCRIPTION
This ensures that the remaining NGinx config examples are updated to handle WOFF 2 font files.

Closes #674.

Signed-off-by: Guy Elsmore-Paddock <guy@inveniem.com>