### PR TITLE
Let nginx decide on number of worker processes

### DIFF
--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;


### PR DESCRIPTION
From https://www.nginx.com/blog/tuning-nginx/:
In most cases, running one worker process per CPU core works well,
and we recommend setting this directive to auto to achieve that.
There are times when you may want to increase this number,
such as when the worker processes have to do a lot of disk I/O.