### PR TITLE
Fix Broken Redis session handler with unix socket #730

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -5,8 +5,9 @@ if (getenv('REDIS_HOST')) {
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
       'host' => getenv('REDIS_HOST'),
-      'port' => getenv('REDIS_HOST_PORT') ?: 6379,
     ),
   );
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = getenv('REDIS_HOST_PORT');
+  }
 }
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         echo "Configuring Redis as session handler"
         {
             echo 'session.save_handler = redis'
-            echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            if [ "${REDIS_HOST_PORT:-0}" -eq 0 ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?persistent=1&weight=1&database=0\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 


### PR DESCRIPTION
Fix Broken Redis session handler with unix socket #730

Without more patches redis can be used now in socket mode, setting REDIS_HOST to socket path and REDIS_HOST_PORT to 0

The RedisFactory.php server file must be patched if we want to avoid having to establish REDIS_HOST_PORT