### PR TITLE
Retry docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
     (
       set -Eeuo pipefail
       set -x
-      docker build -t "$image" "${VERSION}/${VARIANT}"
+      travis_retry docker build -t "$image" "${VERSION}/${VARIANT}"
       ~/official-images/test/run.sh "$image"
       .travis/test-example-dockerfiles.sh "$image"
     )


### PR DESCRIPTION
This should fix the ci failures cause by the unstable https://download.nextcloud.com/

For example: https://travis-ci.org/nextcloud/docker/jobs/531580371