### PR TITLE
Install imap php extension

### DIFF
--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -23,11 +23,13 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libc-client-dev \
         libcurl4-openssl-dev \
         libevent-dev \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \
+        libkrb5-dev \
         libldap2-dev \
         libmcrypt-dev \
         libmemcached-dev \
@@ -40,9 +42,11 @@ RUN set -ex; \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install \
         exif \
         gd \
+        imap \
         intl \
         ldap \
         opcache \

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -23,11 +23,13 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libc-client-dev \
         libcurl4-openssl-dev \
         libevent-dev \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \
+        libkrb5-dev \
         libldap2-dev \
         libmcrypt-dev \
         libmemcached-dev \
@@ -40,10 +42,12 @@ RUN set -ex; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \
         gd \
+        imap \
         intl \
         ldap \
         opcache \

--- a/16.0/apache/Dockerfile
+++ b/16.0/apache/Dockerfile
@@ -23,11 +23,13 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libc-client-dev \
         libcurl4-openssl-dev \
         libevent-dev \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \
+        libkrb5-dev \
         libldap2-dev \
         libmcrypt-dev \
         libmemcached-dev \
@@ -40,10 +42,12 @@ RUN set -ex; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \
         gd \
+        imap \
         intl \
         ldap \
         opcache \


### PR DESCRIPTION
In order to use the [user external](https://github.com/nextcloud/apps/tree/master/user_external) app with imap, the php imap extension needs to get installed.
