### PR TITLE
Enable WEBP support

### DIFF
--- a/14.0/apache/Dockerfile
+++ b/14.0/apache/Dockerfile
@@ -35,10 +35,11 @@ RUN set -ex; \
         libpq-dev \
         libxml2-dev \
         libmagickwand-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/14.0/fpm-alpine/Dockerfile
+++ b/14.0/fpm-alpine/Dockerfile
@@ -30,9 +30,10 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
         imagemagick-dev \
+        libwebp-dev \
     ; \
     \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install \
         exif \

--- a/14.0/fpm/Dockerfile
+++ b/14.0/fpm/Dockerfile
@@ -35,10 +35,11 @@ RUN set -ex; \
         libpq-dev \
         libxml2-dev \
         libmagickwand-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/15.0/apache/Dockerfile
+++ b/15.0/apache/Dockerfile
@@ -36,10 +36,11 @@ RUN set -ex; \
         libxml2-dev \
         libmagickwand-dev \
         libzip-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/15.0/fpm-alpine/Dockerfile
+++ b/15.0/fpm-alpine/Dockerfile
@@ -31,9 +31,10 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
         imagemagick-dev \
+        libwebp-dev \
     ; \
     \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install \
         exif \

--- a/15.0/fpm/Dockerfile
+++ b/15.0/fpm/Dockerfile
@@ -36,10 +36,11 @@ RUN set -ex; \
         libxml2-dev \
         libmagickwand-dev \
         libzip-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/16.0/apache/Dockerfile
+++ b/16.0/apache/Dockerfile
@@ -36,10 +36,11 @@ RUN set -ex; \
         libxml2-dev \
         libmagickwand-dev \
         libzip-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/16.0/fpm-alpine/Dockerfile
+++ b/16.0/fpm-alpine/Dockerfile
@@ -31,9 +31,10 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
         imagemagick-dev \
+        libwebp-dev \
     ; \
     \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install \
         exif \

--- a/16.0/fpm/Dockerfile
+++ b/16.0/fpm/Dockerfile
@@ -36,10 +36,11 @@ RUN set -ex; \
         libxml2-dev \
         libmagickwand-dev \
         libzip-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -30,9 +30,10 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
         imagemagick-dev \
+        libwebp-dev \
     ; \
     \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install \
         exif \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -35,10 +35,11 @@ RUN set -ex; \
         libxml2-dev \
         libmagickwand-dev \
         libzip-dev \
+        libwebp-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \


### PR DESCRIPTION
Enable WEBP support in GD module, so that processing webp files in nextcloud will work.

I created a small app https://github.com/Flow86/preview_webp to allow preview of webp files in nextcloud file browser.