### PR TITLE
Readme: improve migration from existing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,22 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
   -            "writable" => true,
   -    ),
   ```
-  3. Make sure your data directory is set to /var/www/html/data
+  3. Make sure to have the `apps` directory non writable and the `custom_apps` directory writable
+  ```php
+  'apps_paths' => array (
+    0 => array (
+      'path' => '/var/www/html/apps',
+      'url' => '/apps',
+      'writable' => false,
+    ),
+    1 => array (
+      'path' => '/var/www/html/custom_apps',
+      'url' => '/custom_apps',
+      'writable' => true,
+    ),
+  ),
+  ```
+  4. Make sure your data directory is set to /var/www/html/data
   ```php
   'datadirectory' => '/var/www/html/data',
   ```

--- a/README.md
+++ b/README.md
@@ -386,16 +386,16 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 4. Copy your data (nextcloud_app_1 is the name of your Nextcloud container):
 ```console
-docker cp ./data/ nextcloud_app_1:/var/www/html/data
+docker cp ./data/ nextcloud_app_1:/var/www/html/
 docker-compose exec app chown -R www-data:www-data /var/www/html/data
-docker cp ./theming/ nextcloud_app_1:/var/www/html/theming
+docker cp ./theming/ nextcloud_app_1:/var/www/html/
 docker-compose exec app chown -R www-data:www-data /var/www/html/theming
 docker cp ./config/config.php nextcloud_app_1:/var/www/html/config
 docker-compose exec app chown -R www-data:www-data /var/www/html/config
 ```
 5. Copy only the custom apps you use (or simply redownload them from the web interface):
 ```console
-docker cp ./apps/ nextcloud_data:/var/www/html/custom_apps
+docker cp ./custom_apps/ nextcloud_data:/var/www/html/
 docker-compose exec app chown -R www-data:www-data /var/www/html/custom_apps
 ```
 

--- a/README.md
+++ b/README.md
@@ -347,16 +347,28 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
 
 1. Define your whole Nextcloud infrastructure in a `docker-compose` file and run it with `docker-compose up -d` to get the base installation, volumes and database. Work from there.
 2. Restore your database from a mysqldump (nextcloud\_db\_1 is the name of your db container)
-```console
-docker cp ./database.dmp nextcloud_db_1:/dmp
-docker-compose exec db sh -c "mysql -u USER -pPASSWORD nextcloud < /dmp"
-docker-compose exec db rm /dmp
-```
+  - To import from a MySQL dump use the following commands
+    ```console
+    docker cp ./database.dmp nextcloud_db_1:/dmp
+    docker-compose exec db sh -c "mysql -u USER -pPASSWORD nextcloud < /dmp"
+    docker-compose exec db rm /dmp
+    ```
+  - To import from a PostgreSQL dump use to following commands
+    ```console
+    docker cp ./database.dmp nextcloud_db_1:/dmp
+    docker-compose exec db sh -c "psql -U USER --set ON_ERROR_STOP=on nextcloud < /dmp"
+    docker-compose exec db rm /dmp
+    ```
 3. Edit your config.php
   1. Set database connection
-  ```php
-  'dbhost' => 'db:3306',
-  ```
+     - In case of MySQL database
+      ```php
+      'dbhost' => 'db:3306',
+      ```
+     - In case of PostgreSQL database
+      ```php
+      'dbhost' => 'db:5432',
+      ```
   2. Make sure you have no configuration for the `apps_paths`. Delete lines like these
   ```diff
   - "apps_paths" => array (


### PR DESCRIPTION
This PR consists of three parts to improve the migration subsection:

1. add postgresql commands to migration section
in the migration section it is assumed the previous installation was using MySQL. Make the MySQL specific statements explicit and add PostgreSQL specific instructions

2. copy commands copied into existing folders
When the docker-compose up is run the first time the nextcloud
directories are created. When after that the `docker cp` command copies
whole folders they are added as subfolders to the existing folders.

For example, when copying the data folder with
```
docker cp ./data/ nextcloud_app_1:/var/www/html/data
```

afterwards the data folder is in `/var/www/html/data/data`

3. and last mention custom_apps config
I had a hard time figuring out why my apps, which I copied to `custom_apps` folder were not recognized