### PR TITLE
Correct supervisord examples so that the container can start

### DIFF
--- a/.examples/dockerfiles/cron/apache/Dockerfile
+++ b/.examples/dockerfiles/cron/apache/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir /var/log/supervisord /var/run/supervisord
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/.examples/dockerfiles/cron/fpm-alpine/Dockerfile
+++ b/.examples/dockerfiles/cron/fpm-alpine/Dockerfile
@@ -3,8 +3,8 @@ FROM nextcloud:fpm-alpine
 RUN apk add --no-cache supervisor \
   && mkdir /var/log/supervisord /var/run/supervisord
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/.examples/dockerfiles/cron/fpm/Dockerfile
+++ b/.examples/dockerfiles/cron/fpm/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir /var/log/supervisord /var/run/supervisord
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/.examples/dockerfiles/full/apache/Dockerfile
+++ b/.examples/dockerfiles/full/apache/Dockerfile
@@ -52,8 +52,8 @@ RUN mkdir -p \
     /var/run/supervisord \
 ;
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/.examples/dockerfiles/full/fpm-alpine/Dockerfile
+++ b/.examples/dockerfiles/full/fpm-alpine/Dockerfile
@@ -44,8 +44,8 @@ RUN mkdir -p \
     /var/run/supervisord \
 ;
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/.examples/dockerfiles/full/fpm/Dockerfile
+++ b/.examples/dockerfiles/full/fpm/Dockerfile
@@ -52,8 +52,8 @@ RUN mkdir -p \
     /var/run/supervisord \
 ;
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisord.conf /
 
 ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]


### PR DESCRIPTION
Inspired by #847, I selected the rootdir as the place for our configuration
since we already chuck a few files there as seen by https://github.com/nextcloud/docker/blob/master/17.0/fpm-alpine/Dockerfile#L122.

Suggested-by: mikecai <mikecai@us.ibm.com>