### PR TITLE
Avoid pecl prompt

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -50,10 +50,10 @@ RUN set -ex; \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install APCu-%%APCU_VERSION%%; \
-    pecl install memcached-%%MEMCACHED_VERSION%%; \
-    pecl install redis-%%REDIS_VERSION%%; \
-    pecl install imagick-%%IMAGICK_VERSION%%; \
+    printf "\n" | pecl install APCu-%%APCU_VERSION%%; \
+    printf "\n" | pecl install memcached-%%MEMCACHED_VERSION%%; \
+    printf "\n" | pecl install redis-%%REDIS_VERSION%%; \
+    printf "\n" | pecl install imagick-%%IMAGICK_VERSION%%; \
     \
     docker-php-ext-enable \
         apcu \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -58,10 +58,10 @@ RUN set -ex; \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install APCu-%%APCU_VERSION%%; \
-    pecl install memcached-%%MEMCACHED_VERSION%%; \
-    pecl install redis-%%REDIS_VERSION%%; \
-    pecl install imagick-%%IMAGICK_VERSION%%; \
+    printf "\n" | pecl install APCu-%%APCU_VERSION%%; \
+    printf "\n" | pecl install memcached-%%MEMCACHED_VERSION%%; \
+    printf "\n" | pecl install redis-%%REDIS_VERSION%%; \
+    printf "\n" | pecl install imagick-%%IMAGICK_VERSION%%; \
     \
     docker-php-ext-enable \
         apcu \


### PR DESCRIPTION
Building the docker image(s) on my own, I failed with pecl prompting for (interactive) user input. I found the very same problem at https://stackoverflow.com/questions/8141407/install-pecl-modules-without-the-prompts and fixed it.