### PR TITLE
Add support for docker secrets (fix #385)

### DIFF
--- a/15.0/fpm/entrypoint.sh
+++ b/15.0/fpm/entrypoint.sh
@@ -11,6 +11,36 @@ directory_empty() {
     [ -z "$(ls -A "$1/")" ]
 }
 
+# usage: env_secret_expand VAR [DEFAULT]
+# example: env_secret_expand 'XYZ_DB_PASSWORD_FILE' 'password'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+env_secret_expand() {
+    envVar="$1"
+    fileVar="${envVar}_FILE"
+    
+    eval env=\$"$envVar"                # Contains the value of the environment variable
+    eval secretFilepath=\$"$fileVar"    # Contains the filepath to the secret with the value
+
+    if [ -n "$env" ] && [ -n "$secretFilepath" ]; then
+        echo >&2 "error: both $env and $secretFilepath are set (but are exclusive)"
+        exit 1
+    fi
+
+    val=$2 # Set to default
+
+    if [ -n "$secretFilepath" ] && [ -f "$secretFilepath" ]; then 
+        val=$(cat "${secretFilepath}")
+    elif [ -n "$env" ]; then 
+        val="$env"
+    fi
+
+    export "$envVar"="$val"
+
+    unset fileVar
+    unset env
+    unset secretFilepath
+}
+
 run_as() {
     if [ "$(id -u)" = 0 ]; then
         su -p www-data -s /bin/sh -c "$1"
@@ -71,6 +101,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
+
+            env_secret_expand NEXTCLOUD_ADMIN_PASSWORD
+            env_secret_expand MYSQL_PASSWORD
+            env_secret_expand POSTGRES_PASSWORD
 
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016

--- a/16.0/apache/entrypoint.sh
+++ b/16.0/apache/entrypoint.sh
@@ -11,6 +11,36 @@ directory_empty() {
     [ -z "$(ls -A "$1/")" ]
 }
 
+# usage: env_secret_expand VAR [DEFAULT]
+# example: env_secret_expand 'XYZ_DB_PASSWORD_FILE' 'password'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+env_secret_expand() {
+    envVar="$1"
+    fileVar="${envVar}_FILE"
+    
+    eval env=\$"$envVar"                # Contains the value of the environment variable
+    eval secretFilepath=\$"$fileVar"    # Contains the filepath to the secret with the value
+
+    if [ -n "$env" ] && [ -n "$secretFilepath" ]; then
+        echo >&2 "error: both $env and $secretFilepath are set (but are exclusive)"
+        exit 1
+    fi
+
+    val=$2 # Set to default
+
+    if [ -n "$secretFilepath" ] && [ -f "$secretFilepath" ]; then 
+        val=$(cat "${secretFilepath}")
+    elif [ -n "$env" ]; then 
+        val="$env"
+    fi
+
+    export "$envVar"="$val"
+
+    unset fileVar
+    unset env
+    unset secretFilepath
+}
+
 run_as() {
     if [ "$(id -u)" = 0 ]; then
         su -p www-data -s /bin/sh -c "$1"
@@ -71,6 +101,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         #install
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
+
+            env_secret_expand NEXTCLOUD_ADMIN_PASSWORD
+            env_secret_expand MYSQL_PASSWORD
+            env_secret_expand POSTGRES_PASSWORD
 
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016

--- a/17.0/fpm/entrypoint.sh
+++ b/17.0/fpm/entrypoint.sh
@@ -19,6 +19,36 @@ run_as() {
     fi
 }
 
+# usage: env_secret_expand VAR [DEFAULT]
+# example: env_secret_expand 'XYZ_DB_PASSWORD_FILE' 'password'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+env_secret_expand() {
+    envVar="$1"
+    fileVar="${envVar}_FILE"
+    
+    eval env=\$"$envVar"                # Contains the value of the environment variable
+    eval secretFilepath=\$"$fileVar"    # Contains the filepath to the secret with the value
+
+    if [ -n "$env" ] && [ -n "$secretFilepath" ]; then
+        echo >&2 "error: both $env and $secretFilepath are set (but are exclusive)"
+        exit 1
+    fi
+
+    val=$2 # Set to default
+
+    if [ -n "$secretFilepath" ] && [ -f "$secretFilepath" ]; then 
+        val=$(cat "${secretFilepath}")
+    elif [ -n "$env" ]; then 
+        val="$env"
+    fi
+
+    export "$envVar"="$val"
+
+    unset fileVar
+    unset env
+    unset secretFilepath
+}
+
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
@@ -72,6 +102,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         if [ "$installed_version" = "0.0.0.0" ]; then
             echo "New nextcloud instance"
 
+            env_secret_expand NEXTCLOUD_ADMIN_PASSWORD
+            env_secret_expand MYSQL_PASSWORD
+            env_secret_expand POSTGRES_PASSWORD
+            
             if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                 # shellcheck disable=SC2016
                 install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'


### PR DESCRIPTION
Add support for docker secrets (currently for the environment variables NEXTCLOUD_ADMIN-PASSWORD, MYSQL_PASSWORD and POSTGRES_PASSWORD). Updated README with an example for docker secrets.