### PR TITLE
Pass original request protocol to FPM to fix Content Security Policy errors

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/web/nginx.conf
@@ -35,6 +35,11 @@ http {
         server app:9000;
     }
 
+    map $http_x_forwarded_proto $pass_https {
+        default off;
+        https on;
+    }
+
     server {
         listen 80;
 
@@ -119,7 +124,7 @@ http {
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $path_info;
-            # fastcgi_param HTTPS on;
+            fastcgi_param HTTPS $pass_https;
 
             # Avoid sending the security headers twice
             fastcgi_param modHeadersAvailable true;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
@@ -35,6 +35,11 @@ http {
         server app:9000;
     }
 
+    map $http_x_forwarded_proto $pass_https {
+        default off;
+        https on;
+    }
+
     server {
         listen 80;
 
@@ -119,7 +124,7 @@ http {
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $path_info;
-            # fastcgi_param HTTPS on;
+            fastcgi_param HTTPS $pass_https;
 
             # Avoid sending the security headers twice
             fastcgi_param modHeadersAvailable true;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -35,6 +35,11 @@ http {
         server app:9000;
     }
 
+    map $http_x_forwarded_proto $pass_https {
+        default off;
+        https on;
+    }
+
     server {
         listen 80;
 
@@ -119,7 +124,7 @@ http {
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $path_info;
-            # fastcgi_param HTTPS on;
+            fastcgi_param HTTPS $pass_https;
 
             # Avoid sending the security headers twice
             fastcgi_param modHeadersAvailable true;

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -35,6 +35,11 @@ http {
         server app:9000;
     }
 
+    map $http_x_forwarded_proto $pass_https {
+        default off;
+        https on;
+    }
+
     server {
         listen 80;
 
@@ -119,7 +124,7 @@ http {
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $path_info;
-            # fastcgi_param HTTPS on;
+            fastcgi_param HTTPS $pass_https;
 
             # Avoid sending the security headers twice
             fastcgi_param modHeadersAvailable true;


### PR DESCRIPTION
The Nginx config for the proxied FPM images does not set HTTPS as enabled by default. This caused an issue for me in the client login screen where clicking "Accept" would seem to time out. Chrome shows an error in the console like `Refused to send form data to 'http://cloud.domainname/' because it violates the following Content Security Policy directive: "form-action 'self'"`.

This change will pass the original request protocol via the FastCGI `HTTPS` param, so I think it should cover both HTTP and HTTPS.

The details of the error and suggested fix are described in nextcloud/server#17409.