### PR TITLE
Minor typo on MySql import migration command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
   - To import from a MySQL dump use the following commands
     ```console
     docker cp ./database.dmp nextcloud_db_1:/dmp
-    docker-compose exec db sh -c "mysql -u USER -pPASSWORD nextcloud < /dmp"
+    docker-compose exec db sh -c "mysql -u USER -p PASSWORD nextcloud < /dmp"
     docker-compose exec db rm /dmp
     ```
   - To import from a PostgreSQL dump use to following commands


### PR DESCRIPTION
Hello, 

I stumbled upon a typo in the README I copy pasted and used variable substition to run.
I know it's a very tiny fix but it could still help some people.

It's just a whitespace that has been forgotton in between `-p` and `PASSWORD`.