### PR TITLE
Rename imagick extension package for buster compat

### DIFF
--- a/.examples/README.md
+++ b/.examples/README.md
@@ -50,7 +50,7 @@ The required steps for each optional/recommended package that is not already in 
 `apt install ffmpeg`
 
 #### imagemagick SVG support
-`apt install libmagickcore-6.q16-3-extra`
+`apt install libmagickcore-6.q16-6-extra`
 
 #### LibreOffice
 `apt install libreoffice`

--- a/.examples/dockerfiles/full/apache/Dockerfile
+++ b/.examples/dockerfiles/full/apache/Dockerfile
@@ -5,7 +5,7 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ffmpeg \
-        libmagickcore-6.q16-3-extra \
+        libmagickcore-6.q16-6-extra \
         procps \
         smbclient \
         supervisor \

--- a/.examples/dockerfiles/full/fpm/Dockerfile
+++ b/.examples/dockerfiles/full/fpm/Dockerfile
@@ -5,7 +5,7 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ffmpeg \
-        libmagickcore-6.q16-3-extra \
+        libmagickcore-6.q16-6-extra \
         procps \
         smbclient \
         supervisor \


### PR DESCRIPTION
`libmagickcore-6.q16-3-extra` was replaced by `libmagickcore-6.q16-6-extra` in Debian Buster.

This PR updates the examples to use the newer package.