### PR TITLE
Set Cache-Control header

### DIFF
--- a/16.0/apache/Dockerfile
+++ b/16.0/apache/Dockerfile
@@ -106,7 +106,7 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\

--- a/17.0/apache/Dockerfile
+++ b/17.0/apache/Dockerfile
@@ -106,7 +106,7 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\

--- a/18.0/apache/Dockerfile
+++ b/18.0/apache/Dockerfile
@@ -106,7 +106,7 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\

--- a/19.0-beta/apache/Dockerfile
+++ b/19.0-beta/apache/Dockerfile
@@ -106,7 +106,7 @@ RUN { \
 
 VOLUME /var/www/html
 
-RUN a2enmod rewrite remoteip ;\
+RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
      echo RemoteIPTrustedProxy 10.0.0.0/8 ;\

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
 	[fpm]=''
 	[fpm-alpine]=''
 )


### PR DESCRIPTION
This change sets the ``Cache-Control``-Header to the value of the [official documentation](https://docs.nextcloud.com/server/18/admin_manual/installation/nginx.html).
I run Nextcloud behind Traefik which can't set those headers properly and I think those changes benefit the default docker image.

I tested this on my private Nextcloud instance where is works flawlessly and reduced the transferred resources from 8.7MB to 52KB.