### PR TITLE
update version to latest (18.0.6 and 17.0.7)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A release_channel=(
-	[stable]='18.0.4'
-	[production]='17.0.6'
+	[stable]='18.0.6'
+	[production]='17.0.7'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Update the script to generate official image to latest version as they have been published a while ago.

Despite the tags present on docker hub, the **production** image seems to still be in version 17.0.6 (not checked for 18.0)