### PR TITLE
Fix triggering install and update script

### DIFF
--- a/17.0/apache/entrypoint.sh
+++ b/17.0/apache/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/17.0/fpm-alpine/entrypoint.sh
+++ b/17.0/fpm-alpine/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/17.0/fpm/entrypoint.sh
+++ b/17.0/fpm/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/18.0/apache/entrypoint.sh
+++ b/18.0/apache/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/18.0/fpm-alpine/entrypoint.sh
+++ b/18.0/fpm-alpine/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/18.0/fpm/entrypoint.sh
+++ b/18.0/fpm/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/19.0/apache/entrypoint.sh
+++ b/19.0/apache/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/19.0/fpm-alpine/entrypoint.sh
+++ b/19.0/fpm-alpine/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/19.0/fpm/entrypoint.sh
+++ b/19.0/fpm/entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ One or more trusted domains can be set through environment variable, too. They w
 
 - `NEXTCLOUD_TRUSTED_DOMAINS` (not set by default) Optional space-separated list of domains
 
-The install and update script is only triggered when a default command is used (`apache-foreground` or `php-fpm`). If you use a custom command you have to enable the install / update with
+The install and update script is only triggered when a default command is used (`apache2-foreground` or `php-fpm`). If you use a custom command you have to enable the install / update with
 
 - `NEXTCLOUD_UPDATE` (default: _0_)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,13 +43,13 @@ file_env() {
     unset "$fileVar"
 }
 
-if expr "$1" : "apache" 1>/dev/null; then
+if expr "$1" : "apache2-foreground" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
     fi
 fi
 
-if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+if expr "$1" : "apache2-foreground" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
     if [ -n "${REDIS_HOST+x}" ]; then
 
         echo "Configuring Redis as session handler"


### PR DESCRIPTION
The default commands set in Dockerfile, entrypoint.sh and README.me were out of sync. Therefore, the install and update script was not trigger at initial startup unless `NEXTCLOUD_UPDATE=1` were set.