### PR TITLE
Update stable to 18.0.7 and production to 17.0.8

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A release_channel=(
-	[stable]='18.0.6'
-	[production]='17.0.7'
+	[stable]='18.0.7'
+	[production]='17.0.8'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
With https://github.com/nextcloud/updater_server/commit/0aeb993e31ede6beaa9a8dcf6539e098a3b8af5e version 19.0.1 was raised to stable and production in the updater-server, but that is currently not reflected in the docker tags.
Is this change enough to fix this? Or do I need to do anything else?

**Update (27.07.20)**:
As mentioned by @tilosp, the 17 and 18 tracks only get the next new patch version. This PR now reflects that change and updates 18 to 18.0.7 and 17 to 18.0.8.