### PR TITLE
Adds ability to configure S3 object stores via environment variables

### DIFF
--- a/.config/s3.config.php
+++ b/.config/s3.config.php
@@ -1,0 +1,21 @@
+<?php
+if (getenv('OBJECTSTORE_S3_BUCKET')) {
+  $use_ssl = getenv('OBJECTSTORE_S3_SSL');
+  $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $CONFIG = array(
+    'objectstore' => array(
+      'class' => '\OC\Files\ObjectStore\S3',
+      'arguments' => array(
+        'bucket' => getenv('OBJECTSTORE_S3_BUCKET'),
+        'key' => getenv('OBJECTSTORE_S3_KEY') ?: '',
+        'secret' => getenv('OBJECTSTORE_S3_SECRET') ?: '',
+        'region' => getenv('OBJECTSTORE_S3_REGION') ?: '',
+        'hostname' => getenv('OBJECTSTORE_S3_HOST') ?: '',
+        'port' => getenv('OBJECTSTORE_S3_PORT') ?: '',
+        'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
+        // required for some non Amazon S3 implementations
+        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+      )
+    )
+  );
+}

--- a/17.0-rc/apache/Dockerfile
+++ b/17.0-rc/apache/Dockerfile
@@ -1,0 +1,151 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.3-apache-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [ ! -e /usr/include/gmp.h ]; then ln -s /usr/include/$debMultiarch/gmp.h /usr/include/gmp.h; fi;\
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure gmp --with-gmp="/usr/include/$debMultiarch"; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+RUN a2enmod headers rewrite remoteip ;\
+    {\
+     echo RemoteIPHeader X-Real-IP ;\
+     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+    } > /etc/apache2/conf-available/remoteip.conf;\
+    a2enconf remoteip
+
+ENV NEXTCLOUD_VERSION 17.0.9RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/17.0-rc/apache/config/apache-pretty-urls.config.php
+++ b/17.0-rc/apache/config/apache-pretty-urls.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'htaccess.RewriteBase' => '/',
+);

--- a/17.0-rc/apache/config/apcu.config.php
+++ b/17.0-rc/apache/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/17.0-rc/apache/config/apps.config.php
+++ b/17.0-rc/apache/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/17.0-rc/apache/config/autoconfig.php
+++ b/17.0-rc/apache/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/17.0-rc/apache/config/redis.config.php
+++ b/17.0-rc/apache/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/17.0-rc/apache/config/reverse-proxy.config.php
+++ b/17.0-rc/apache/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/17.0-rc/apache/config/smtp.config.php
+++ b/17.0-rc/apache/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/17.0-rc/apache/cron.sh
+++ b/17.0-rc/apache/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/17.0-rc/apache/entrypoint.sh
+++ b/17.0-rc/apache/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/17.0-rc/apache/upgrade.exclude
+++ b/17.0-rc/apache/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/17.0-rc/fpm-alpine/Dockerfile
+++ b/17.0-rc/fpm-alpine/Dockerfile
@@ -1,0 +1,126 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
+FROM php:7.3-fpm-alpine3.12
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apk add --no-cache \
+        rsync \
+    ; \
+    \
+    rm /var/spool/cron/crontabs/root; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        autoconf \
+        freetype-dev \
+        icu-dev \
+        libevent-dev \
+        libjpeg-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libmemcached-dev \
+        libxml2-dev \
+        libzip-dev \
+        openldap-dev \
+        pcre-dev \
+        postgresql-dev \
+        imagemagick-dev \
+        libwebp-dev \
+        gmp-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure ldap; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 17.0.9RC2
+
+RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+        bzip2 \
+        gnupg \
+    ; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    apk del .fetch-deps
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/17.0-rc/fpm-alpine/config/apcu.config.php
+++ b/17.0-rc/fpm-alpine/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/17.0-rc/fpm-alpine/config/apps.config.php
+++ b/17.0-rc/fpm-alpine/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/17.0-rc/fpm-alpine/config/autoconfig.php
+++ b/17.0-rc/fpm-alpine/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/17.0-rc/fpm-alpine/config/redis.config.php
+++ b/17.0-rc/fpm-alpine/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/17.0-rc/fpm-alpine/config/reverse-proxy.config.php
+++ b/17.0-rc/fpm-alpine/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/17.0-rc/fpm-alpine/config/smtp.config.php
+++ b/17.0-rc/fpm-alpine/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/17.0-rc/fpm-alpine/cron.sh
+++ b/17.0-rc/fpm-alpine/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/17.0-rc/fpm-alpine/entrypoint.sh
+++ b/17.0-rc/fpm-alpine/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/17.0-rc/fpm-alpine/upgrade.exclude
+++ b/17.0-rc/fpm-alpine/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/17.0-rc/fpm/Dockerfile
+++ b/17.0-rc/fpm/Dockerfile
@@ -1,0 +1,143 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.3-fpm-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [ ! -e /usr/include/gmp.h ]; then ln -s /usr/include/$debMultiarch/gmp.h /usr/include/gmp.h; fi;\
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure gmp --with-gmp="/usr/include/$debMultiarch"; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 17.0.9RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/17.0-rc/fpm/config/apcu.config.php
+++ b/17.0-rc/fpm/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/17.0-rc/fpm/config/apps.config.php
+++ b/17.0-rc/fpm/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/17.0-rc/fpm/config/autoconfig.php
+++ b/17.0-rc/fpm/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/17.0-rc/fpm/config/redis.config.php
+++ b/17.0-rc/fpm/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/17.0-rc/fpm/config/reverse-proxy.config.php
+++ b/17.0-rc/fpm/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/17.0-rc/fpm/config/smtp.config.php
+++ b/17.0-rc/fpm/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/17.0-rc/fpm/cron.sh
+++ b/17.0-rc/fpm/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/17.0-rc/fpm/entrypoint.sh
+++ b/17.0-rc/fpm/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/17.0-rc/fpm/upgrade.exclude
+++ b/17.0-rc/fpm/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/18.0-rc/apache/Dockerfile
+++ b/18.0-rc/apache/Dockerfile
@@ -1,0 +1,151 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.3-apache-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [ ! -e /usr/include/gmp.h ]; then ln -s /usr/include/$debMultiarch/gmp.h /usr/include/gmp.h; fi;\
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure gmp --with-gmp="/usr/include/$debMultiarch"; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+RUN a2enmod headers rewrite remoteip ;\
+    {\
+     echo RemoteIPHeader X-Real-IP ;\
+     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+    } > /etc/apache2/conf-available/remoteip.conf;\
+    a2enconf remoteip
+
+ENV NEXTCLOUD_VERSION 18.0.8RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/18.0-rc/apache/config/apache-pretty-urls.config.php
+++ b/18.0-rc/apache/config/apache-pretty-urls.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'htaccess.RewriteBase' => '/',
+);

--- a/18.0-rc/apache/config/apcu.config.php
+++ b/18.0-rc/apache/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/18.0-rc/apache/config/apps.config.php
+++ b/18.0-rc/apache/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/18.0-rc/apache/config/autoconfig.php
+++ b/18.0-rc/apache/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/18.0-rc/apache/config/redis.config.php
+++ b/18.0-rc/apache/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/18.0-rc/apache/config/reverse-proxy.config.php
+++ b/18.0-rc/apache/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/18.0-rc/apache/config/smtp.config.php
+++ b/18.0-rc/apache/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/18.0-rc/apache/cron.sh
+++ b/18.0-rc/apache/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/18.0-rc/apache/entrypoint.sh
+++ b/18.0-rc/apache/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/18.0-rc/apache/upgrade.exclude
+++ b/18.0-rc/apache/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/18.0-rc/fpm-alpine/Dockerfile
+++ b/18.0-rc/fpm-alpine/Dockerfile
@@ -1,0 +1,126 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
+FROM php:7.3-fpm-alpine3.12
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apk add --no-cache \
+        rsync \
+    ; \
+    \
+    rm /var/spool/cron/crontabs/root; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        autoconf \
+        freetype-dev \
+        icu-dev \
+        libevent-dev \
+        libjpeg-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libmemcached-dev \
+        libxml2-dev \
+        libzip-dev \
+        openldap-dev \
+        pcre-dev \
+        postgresql-dev \
+        imagemagick-dev \
+        libwebp-dev \
+        gmp-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure ldap; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 18.0.8RC2
+
+RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+        bzip2 \
+        gnupg \
+    ; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    apk del .fetch-deps
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/18.0-rc/fpm-alpine/config/apcu.config.php
+++ b/18.0-rc/fpm-alpine/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/18.0-rc/fpm-alpine/config/apps.config.php
+++ b/18.0-rc/fpm-alpine/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/18.0-rc/fpm-alpine/config/autoconfig.php
+++ b/18.0-rc/fpm-alpine/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/18.0-rc/fpm-alpine/config/redis.config.php
+++ b/18.0-rc/fpm-alpine/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/18.0-rc/fpm-alpine/config/reverse-proxy.config.php
+++ b/18.0-rc/fpm-alpine/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/18.0-rc/fpm-alpine/config/smtp.config.php
+++ b/18.0-rc/fpm-alpine/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/18.0-rc/fpm-alpine/cron.sh
+++ b/18.0-rc/fpm-alpine/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/18.0-rc/fpm-alpine/entrypoint.sh
+++ b/18.0-rc/fpm-alpine/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/18.0-rc/fpm-alpine/upgrade.exclude
+++ b/18.0-rc/fpm-alpine/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/18.0-rc/fpm/Dockerfile
+++ b/18.0-rc/fpm/Dockerfile
@@ -1,0 +1,143 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.3-fpm-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [ ! -e /usr/include/gmp.h ]; then ln -s /usr/include/$debMultiarch/gmp.h /usr/include/gmp.h; fi;\
+    docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
+    docker-php-ext-configure gmp --with-gmp="/usr/include/$debMultiarch"; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 18.0.8RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/18.0-rc/fpm/config/apcu.config.php
+++ b/18.0-rc/fpm/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/18.0-rc/fpm/config/apps.config.php
+++ b/18.0-rc/fpm/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/18.0-rc/fpm/config/autoconfig.php
+++ b/18.0-rc/fpm/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/18.0-rc/fpm/config/redis.config.php
+++ b/18.0-rc/fpm/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/18.0-rc/fpm/config/reverse-proxy.config.php
+++ b/18.0-rc/fpm/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/18.0-rc/fpm/config/smtp.config.php
+++ b/18.0-rc/fpm/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/18.0-rc/fpm/cron.sh
+++ b/18.0-rc/fpm/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/18.0-rc/fpm/entrypoint.sh
+++ b/18.0-rc/fpm/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/18.0-rc/fpm/upgrade.exclude
+++ b/18.0-rc/fpm/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/19.0-rc/apache/Dockerfile
+++ b/19.0-rc/apache/Dockerfile
@@ -1,0 +1,150 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.4-apache-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+RUN a2enmod headers rewrite remoteip ;\
+    {\
+     echo RemoteIPHeader X-Real-IP ;\
+     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+    } > /etc/apache2/conf-available/remoteip.conf;\
+    a2enconf remoteip
+
+ENV NEXTCLOUD_VERSION 19.0.2RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/19.0-rc/apache/config/apache-pretty-urls.config.php
+++ b/19.0-rc/apache/config/apache-pretty-urls.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'htaccess.RewriteBase' => '/',
+);

--- a/19.0-rc/apache/config/apcu.config.php
+++ b/19.0-rc/apache/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/19.0-rc/apache/config/apps.config.php
+++ b/19.0-rc/apache/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/19.0-rc/apache/config/autoconfig.php
+++ b/19.0-rc/apache/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/19.0-rc/apache/config/redis.config.php
+++ b/19.0-rc/apache/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/19.0-rc/apache/config/reverse-proxy.config.php
+++ b/19.0-rc/apache/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/19.0-rc/apache/config/smtp.config.php
+++ b/19.0-rc/apache/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/19.0-rc/apache/cron.sh
+++ b/19.0-rc/apache/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/19.0-rc/apache/entrypoint.sh
+++ b/19.0-rc/apache/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/19.0-rc/apache/upgrade.exclude
+++ b/19.0-rc/apache/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/19.0-rc/fpm-alpine/Dockerfile
+++ b/19.0-rc/fpm-alpine/Dockerfile
@@ -1,0 +1,127 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
+FROM php:7.4-fpm-alpine3.12
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apk add --no-cache \
+        rsync \
+    ; \
+    \
+    rm /var/spool/cron/crontabs/root; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        autoconf \
+        freetype-dev \
+        icu-dev \
+        libevent-dev \
+        libjpeg-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libmemcached-dev \
+        libxml2-dev \
+        libzip-dev \
+        openldap-dev \
+        pcre-dev \
+        postgresql-dev \
+        imagemagick-dev \
+        libwebp-dev \
+        gmp-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 19.0.2RC2
+
+RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+        bzip2 \
+        gnupg \
+    ; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    apk del .fetch-deps
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/19.0-rc/fpm-alpine/config/apcu.config.php
+++ b/19.0-rc/fpm-alpine/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/19.0-rc/fpm-alpine/config/apps.config.php
+++ b/19.0-rc/fpm-alpine/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/19.0-rc/fpm-alpine/config/autoconfig.php
+++ b/19.0-rc/fpm-alpine/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/19.0-rc/fpm-alpine/config/redis.config.php
+++ b/19.0-rc/fpm-alpine/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/19.0-rc/fpm-alpine/config/reverse-proxy.config.php
+++ b/19.0-rc/fpm-alpine/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/19.0-rc/fpm-alpine/config/smtp.config.php
+++ b/19.0-rc/fpm-alpine/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/19.0-rc/fpm-alpine/cron.sh
+++ b/19.0-rc/fpm-alpine/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/19.0-rc/fpm-alpine/entrypoint.sh
+++ b/19.0-rc/fpm-alpine/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/19.0-rc/fpm-alpine/upgrade.exclude
+++ b/19.0-rc/fpm-alpine/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/19.0-rc/fpm/Dockerfile
+++ b/19.0-rc/fpm/Dockerfile
@@ -1,0 +1,142 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.4-fpm-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 19.0.2RC2
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/19.0-rc/fpm/config/apcu.config.php
+++ b/19.0-rc/fpm/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/19.0-rc/fpm/config/apps.config.php
+++ b/19.0-rc/fpm/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/19.0-rc/fpm/config/autoconfig.php
+++ b/19.0-rc/fpm/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/19.0-rc/fpm/config/redis.config.php
+++ b/19.0-rc/fpm/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/19.0-rc/fpm/config/reverse-proxy.config.php
+++ b/19.0-rc/fpm/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/19.0-rc/fpm/config/smtp.config.php
+++ b/19.0-rc/fpm/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/19.0-rc/fpm/cron.sh
+++ b/19.0-rc/fpm/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/19.0-rc/fpm/entrypoint.sh
+++ b/19.0-rc/fpm/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/19.0-rc/fpm/upgrade.exclude
+++ b/19.0-rc/fpm/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/20.0-beta/apache/Dockerfile
+++ b/20.0-beta/apache/Dockerfile
@@ -1,0 +1,150 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.4-apache-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+RUN a2enmod headers rewrite remoteip ;\
+    {\
+     echo RemoteIPHeader X-Real-IP ;\
+     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+    } > /etc/apache2/conf-available/remoteip.conf;\
+    a2enconf remoteip
+
+ENV NEXTCLOUD_VERSION 20.0.0beta1
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/20.0-beta/apache/config/apache-pretty-urls.config.php
+++ b/20.0-beta/apache/config/apache-pretty-urls.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'htaccess.RewriteBase' => '/',
+);

--- a/20.0-beta/apache/config/apcu.config.php
+++ b/20.0-beta/apache/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/20.0-beta/apache/config/apps.config.php
+++ b/20.0-beta/apache/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/20.0-beta/apache/config/autoconfig.php
+++ b/20.0-beta/apache/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/20.0-beta/apache/config/redis.config.php
+++ b/20.0-beta/apache/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/20.0-beta/apache/config/reverse-proxy.config.php
+++ b/20.0-beta/apache/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/20.0-beta/apache/config/smtp.config.php
+++ b/20.0-beta/apache/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/20.0-beta/apache/cron.sh
+++ b/20.0-beta/apache/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/20.0-beta/apache/entrypoint.sh
+++ b/20.0-beta/apache/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/20.0-beta/apache/upgrade.exclude
+++ b/20.0-beta/apache/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/20.0-beta/fpm-alpine/Dockerfile
+++ b/20.0-beta/fpm-alpine/Dockerfile
@@ -1,0 +1,127 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
+FROM php:7.4-fpm-alpine3.12
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apk add --no-cache \
+        rsync \
+    ; \
+    \
+    rm /var/spool/cron/crontabs/root; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        autoconf \
+        freetype-dev \
+        icu-dev \
+        libevent-dev \
+        libjpeg-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libmemcached-dev \
+        libxml2-dev \
+        libzip-dev \
+        openldap-dev \
+        pcre-dev \
+        postgresql-dev \
+        imagemagick-dev \
+        libwebp-dev \
+        gmp-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 20.0.0beta1
+
+RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+        bzip2 \
+        gnupg \
+    ; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    apk del .fetch-deps
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/20.0-beta/fpm-alpine/config/apcu.config.php
+++ b/20.0-beta/fpm-alpine/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/20.0-beta/fpm-alpine/config/apps.config.php
+++ b/20.0-beta/fpm-alpine/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/20.0-beta/fpm-alpine/config/autoconfig.php
+++ b/20.0-beta/fpm-alpine/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/20.0-beta/fpm-alpine/config/redis.config.php
+++ b/20.0-beta/fpm-alpine/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/20.0-beta/fpm-alpine/config/reverse-proxy.config.php
+++ b/20.0-beta/fpm-alpine/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/20.0-beta/fpm-alpine/config/smtp.config.php
+++ b/20.0-beta/fpm-alpine/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/20.0-beta/fpm-alpine/cron.sh
+++ b/20.0-beta/fpm-alpine/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/20.0-beta/fpm-alpine/entrypoint.sh
+++ b/20.0-beta/fpm-alpine/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/20.0-beta/fpm-alpine/upgrade.exclude
+++ b/20.0-beta/fpm-alpine/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/20.0-beta/fpm/Dockerfile
+++ b/20.0-beta/fpm/Dockerfile
@@ -1,0 +1,142 @@
+# DO NOT EDIT: created by update.sh from Dockerfile-debian.template
+FROM php:7.4-fpm-buster
+
+# entrypoint.sh and cron.sh dependencies
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        rsync \
+        bzip2 \
+        busybox-static \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    mkdir -p /var/spool/cron/crontabs; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libmagickwand-dev \
+        libzip-dev \
+        libwebp-dev \
+        libgmp-dev \
+    ; \
+    \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+        gmp \
+    ; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.18; \
+    pecl install memcached-3.1.5; \
+    pecl install redis-5.3.1; \
+    pecl install imagick-3.4.4; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        memcached \
+        redis \
+        imagick \
+    ; \
+    \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
+
+VOLUME /var/www/html
+
+
+ENV NEXTCLOUD_VERSION 20.0.0beta1
+
+RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+        dirmngr \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc \
+        "https://download.nextcloud.com/server/prereleases/nextcloud-${NEXTCLOUD_VERSION}.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/20.0-beta/fpm/config/apcu.config.php
+++ b/20.0-beta/fpm/config/apcu.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\OC\Memcache\APCu',
+);

--- a/20.0-beta/fpm/config/apps.config.php
+++ b/20.0-beta/fpm/config/apps.config.php
@@ -1,0 +1,15 @@
+<?php
+$CONFIG = array (
+  "apps_paths" => array (
+      0 => array (
+              "path"     => OC::$SERVERROOT."/apps",
+              "url"      => "/apps",
+              "writable" => false,
+      ),
+      1 => array (
+              "path"     => OC::$SERVERROOT."/custom_apps",
+              "url"      => "/custom_apps",
+              "writable" => true,
+      ),
+  ),
+);

--- a/20.0-beta/fpm/config/autoconfig.php
+++ b/20.0-beta/fpm/config/autoconfig.php
@@ -1,0 +1,27 @@
+<?php
+
+$autoconfig_enabled = false;
+
+if (getenv('SQLITE_DATABASE')) {
+    $AUTOCONFIG["dbtype"] = "sqlite";
+    $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+    $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG["dbtype"] = "mysql";
+    $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+    $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG["dbtype"] = "pgsql";
+    $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+    $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+    $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+}
+
+if ($autoconfig_enabled) {
+    $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+}

--- a/20.0-beta/fpm/config/redis.config.php
+++ b/20.0-beta/fpm/config/redis.config.php
@@ -1,0 +1,17 @@
+<?php
+if (getenv('REDIS_HOST')) {
+  $CONFIG = array (
+    'memcache.distributed' => '\OC\Memcache\Redis',
+    'memcache.locking' => '\OC\Memcache\Redis',
+    'redis' => array(
+      'host' => getenv('REDIS_HOST'),
+      'password' => getenv('REDIS_HOST_PASSWORD'),
+    ),
+  );
+
+  if (getenv('REDIS_HOST_PORT') !== false) {
+    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
+  } elseif (getenv('REDIS_HOST')[0] != '/') {
+    $CONFIG['redis']['port'] = 6379;
+  }
+}

--- a/20.0-beta/fpm/config/reverse-proxy.config.php
+++ b/20.0-beta/fpm/config/reverse-proxy.config.php
@@ -1,0 +1,25 @@
+<?php
+$overwriteHost = getenv('OVERWRITEHOST');
+if ($overwriteHost) {
+  $CONFIG['overwritehost'] = $overwriteHost;
+}
+
+$overwriteProtocol = getenv('OVERWRITEPROTOCOL');
+if ($overwriteProtocol) {
+  $CONFIG['overwriteprotocol'] = $overwriteProtocol;
+}
+
+$overwriteWebRoot = getenv('OVERWRITEWEBROOT');
+if ($overwriteWebRoot) {
+  $CONFIG['overwritewebroot'] = $overwriteWebRoot;
+}
+
+$overwriteCondAddr = getenv('OVERWRITECONDADDR');
+if ($overwriteCondAddr) {
+  $CONFIG['overwritecondaddr'] = $overwriteCondAddr;
+}
+
+$trustedProxies = getenv('TRUSTED_PROXIES');
+if ($trustedProxies) {
+  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+}

--- a/20.0-beta/fpm/config/smtp.config.php
+++ b/20.0-beta/fpm/config/smtp.config.php
@@ -1,0 +1,15 @@
+<?php
+if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+  $CONFIG = array (
+    'mail_smtpmode' => 'smtp',
+    'mail_smtphost' => getenv('SMTP_HOST'),
+    'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+    'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+    'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+    'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+    'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+    'mail_domain' => getenv('MAIL_DOMAIN'),
+  );
+}

--- a/20.0-beta/fpm/cron.sh
+++ b/20.0-beta/fpm/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec busybox crond -f -l 0 -L /dev/stdout

--- a/20.0-beta/fpm/entrypoint.sh
+++ b/20.0-beta/fpm/entrypoint.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+# version_greater A B returns whether A > B
+version_greater() {
+    [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
+}
+
+# return true if specified directory is empty
+directory_empty() {
+    [ -z "$(ls -A "$1/")" ]
+}
+
+run_as() {
+    if [ "$(id -u)" = 0 ]; then
+        su -p www-data -s /bin/sh -c "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+if expr "$1" : "apache" 1>/dev/null; then
+    if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
+        a2disconf remoteip
+    fi
+fi
+
+if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${REDIS_HOST+x}" ]; then
+
+        echo "Configuring Redis as session handler"
+        {
+            echo 'session.save_handler = redis'
+            # check if redis host is an unix socket path
+            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+              if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+              else
+                echo "session.save_path = \"unix://${REDIS_HOST}\""
+              fi
+            # check if redis password has been set
+            elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+            else
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+            fi
+        } > /usr/local/etc/php/conf.d/redis-session.ini
+    fi
+
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown www-data:root"
+        else
+            rsync_options="-rlD"
+        fi
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        echo "Initializing finished"
+
+        #install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "running web-based installer on first connect!"
+                fi
+            fi
+        #upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+    fi
+fi
+
+exec "$@"

--- a/20.0-beta/fpm/upgrade.exclude
+++ b/20.0-beta/fpm/upgrade.exclude
@@ -1,0 +1,5 @@
+/config/
+/data/
+/custom_apps/
+/themes/
+/version.php

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ To use an external SMTP server, you have to provide the connection details. To c
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/email_configuration.html) for other values to configure SMTP.
 
+To use an external S3 compatible object store as primary storage, set the following variables:
+- `OBJECTSTORE_S3_HOST`: The hostname of the object storage server
+- `OBJECTSTORE_S3_BUCKET`: The name of the bucket that Nextcloud should store the data in
+- `OBJECTSTORE_S3_KEY`: AWS style access key
+- `OBJECTSTORE_S3_SECRET`: AWS style secret access key
+- `OBJECTSTORE_S3_PORT`: The port that the object storage server is being served over
+- `OBJECTSTORE_S3_SSL` (default: `true`): Whether or not SSL/TLS should be used to communicate with object storage server
+- `OBJECTSTORE_S3_REGION`: The region that the S3 bucket resides in.
+- `OBJECTSTORE_S3_USEPATH_STYLE` (default: `false`): Not required for AWS S3
+
+Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) for more information.
+
 
 ## Using the apache image behind a reverse proxy and auto configure server host and protocol
 


### PR DESCRIPTION
Allows consumers of the Nextcloud docker image to configure S3 compatible object storage as Nextcloud's primary storage through environment variables. Supporting the configuration of this feature through the environment will make the image that much easier to leverage. Ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3