### PR TITLE
move stable from NC18 to NC19 and production from NC17 o NC18

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A release_channel=(
-	[stable]='18.0.7'
-	[production]='17.0.8'
+	[stable]='19.0.2'
+	[production]='18.0.8'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Fix for #1174 

**Warning**, this PR is upgrading the production and stable version (seems compliant with latest announcement: https://nextcloud.com/blog/updates-19-0-1-18-0-and-17-0-9-are-out-time-to-update/)


