### PR TITLE
fix: set REDIS_HOST_PASSWORD to empty string when not set

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -1,11 +1,11 @@
 <?php
 if (getenv('REDIS_HOST')) {
-  $CONFIG = array (
+  $CONFIG = array(
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
       'host' => getenv('REDIS_HOST'),
-      'password' => getenv('REDIS_HOST_PASSWORD'),
+      'password' => (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );
 


### PR DESCRIPTION
not setting `REDIS_HOST_PASSWORD` currently leads to a "RedisException: ERR AUTH <password> called without any password configured for the default user." error. this seems to happen because `getenv` returns `false`, but the nextcloud server only checks `isset` and for an empty string (see [here](https://github.com/nextcloud/server/blob/master/lib/private/RedisFactory.php#L93)). casting to a string should hopefully fix this???

fixes #1179