### PR TITLE
Starting cron without new docker-container

### DIFF
--- a/19.0/apache/entrypoint.sh
+++ b/19.0/apache/entrypoint.sh
@@ -185,4 +185,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+if [ "${START_CRON}" = "true" ]; then
+  echo "Starting CRON."
+  sh /cron.sh &
+fi
+
+
 exec "$@"

--- a/19.0/fpm-alpine/entrypoint.sh
+++ b/19.0/fpm-alpine/entrypoint.sh
@@ -185,4 +185,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+
+if [ "${START_CRON}" = "true" ]; then
+  sh /cron.sh &
+fi
+
 exec "$@"

--- a/19.0/fpm-alpine/entrypoint.sh
+++ b/19.0/fpm-alpine/entrypoint.sh
@@ -187,6 +187,7 @@ fi
 
 
 if [ "${START_CRON}" = "true" ]; then
+  echo "Starting CRON."
   sh /cron.sh &
 fi
 

--- a/19.0/fpm/entrypoint.sh
+++ b/19.0/fpm/entrypoint.sh
@@ -185,4 +185,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
     fi
 fi
 
+if [ "${START_CRON}" = "true" ]; then
+  echo "Starting CRON."
+  sh /cron.sh &
+fi
+
+
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ __PostgreSQL__:
 - `POSTGRES_PASSWORD` Password for the database user using postgres.
 - `POSTGRES_HOST` Hostname of the database server using postgres.
 
+__CRON__:  
+If you want to use the built-in cron-service, then just the following variable:  
+* `START_CRON` to `true`
+
+
 If you set any values, they will not be asked in the install page on first run. With a complete configuration by using all variables for your database type, you can additionally configure your Nextcloud instance by setting admin user and password (only works if you set both):
 
 - `NEXTCLOUD_ADMIN_USER` Name of the Nextcloud admin user.


### PR DESCRIPTION
Nextxloud should maintain the cron-service without multiple docker-containers which mounts the same directory.

See this issue as reference: https://github.com/nextcloud/docker/issues/627