### PR TITLE
Adds ability to configure swift object store though environment variables

### DIFF
--- a/.config/swift.config.php
+++ b/.config/swift.config.php
@@ -1,0 +1,31 @@
+<?php
+if (getenv('OBJECTSTORE_SWIFT_URL')) {
+    $autocreate = getenv('OBJECTSTORE_SWIFT_AUTOCREATE');
+  $CONFIG = array(
+    'objectstore' => [
+      'class' => 'OC\\Files\\ObjectStore\\Swift',
+      'arguments' => [
+        'autocreate' => $autocreate == true && strtolower($autocreate) !== 'false',
+        'user' => [
+          'name' => getenv('OBJECTSTORE_SWIFT_USER_NAME'),
+          'password' => getenv('OBJECTSTORE_SWIFT_USER_PASSWORD'),
+          'domain' => [
+            'name' => (getenv('OBJECTSTORE_SWIFT_USER_DOMAIN')) ?: 'Default',
+          ],
+        ],
+        'scope' => [
+          'project' => [
+            'name' => getenv('OBJECTSTORE_SWIFT_PROJECT_NAME'),
+            'domain' => [
+              'name' => (getenv('OBJECTSTORE_SWIFT_PROJECT_DOMAIN')) ?: 'Default',
+            ],
+          ],
+        ],
+        'serviceName' => (getenv('OBJECTSTORE_SWIFT_SERVICE_NAME')) ?: 'swift',
+        'region' => getenv('OBJECTSTORE_SWIFT_REGION'),
+        'url' => getenv('OBJECTSTORE_SWIFT_URL'),
+        'bucket' => getenv('OBJECTSTORE_SWIFT_CONTAINER_NAME'),
+      ]
+    ]
+  );
+}

--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ To use an external S3 compatible object store as primary storage, set the follow
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) for more information.
 
+To use an external OpenStack Swift object store as primary storage, set the following variables:
+- `OBJECTSTORE_SWIFT_URL`: The Swift identity (Keystone) endpoint
+- `OBJECTSTORE_SWIFT_AUTOCREATE` (default: `false`): Whether or not Nextcloud should automatically create the Swift container
+- `OBJECTSTORE_SWIFT_USER_NAME`: Swift username
+- `OBJECTSTORE_SWIFT_USER_PASSWORD`: Swift user password
+- `OBJECTSTORE_SWIFT_USER_DOMAIN` (default: `Default`): Swift user domain 
+- `OBJECTSTORE_SWIFT_PROJECT_NAME`: OpenStack project name
+- `OBJECTSTORE_SWIFT_PROJECT_DOMAIN` (default: `Default`): OpenStack project domain
+- `OBJECTSTORE_SWIFT_SERVICE_NAME` (default: `swift`): Swift service name
+- `OBJECTSTORE_SWIFT_SERVICE_REGION`: Swift endpoint region
+- `OBJECTSTORE_SWIFT_CONTAINER_NAME`: Swift container (bucket) that Nextcloud should store the data in
+
+Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#openstack-swift) for more information.
+
 
 ## Using the apache image behind a reverse proxy and auto configure server host and protocol
 


### PR DESCRIPTION
Allows consumers of the Nextcloud docker image to configure OpenStack Swift object storage as Nextcloud's primary storage through environment variables. Supporting the configuration of this feature through the environment will make the image that much easier to leverage. Ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#openstack-swift