### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -96,6 +96,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             rsync_options="-rlD"
         fi
         rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        rsync $rsync_options --delete --exclude config.php /usr/src/nextcloud/config/ /var/www/html/config/
 
         for dir in config data custom_apps themes; do
             if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then


### PR DESCRIPTION
Config files do not seems to get updated during a nextcloud upgrade.

Adding this command should correctly update them.

Instead of adding this cmd we could replace `/config/` by `/config/config.php` in `upgrade.exclude`.

Or maybe I am doing something wrong ?