### PR TITLE
Allow custom script execution on installation

### DIFF
--- a/20.0/apache/entrypoint.sh
+++ b/20.0/apache/entrypoint.sh
@@ -168,6 +168,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                             NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
                         done
                     fi
+
+                    if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
+                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                    fi
                 else
                     echo "running web-based installer on first connect!"
                 fi

--- a/20.0/apache/entrypoint.sh
+++ b/20.0/apache/entrypoint.sh
@@ -170,7 +170,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     fi
 
                     if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
-                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                        run_as "/bin/sh ${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/20.0/fpm-alpine/entrypoint.sh
+++ b/20.0/fpm-alpine/entrypoint.sh
@@ -168,6 +168,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                             NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
                         done
                     fi
+
+                    if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
+                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                    fi
                 else
                     echo "running web-based installer on first connect!"
                 fi

--- a/20.0/fpm-alpine/entrypoint.sh
+++ b/20.0/fpm-alpine/entrypoint.sh
@@ -170,7 +170,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     fi
 
                     if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
-                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                        run_as "/bin/sh ${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/20.0/fpm/entrypoint.sh
+++ b/20.0/fpm/entrypoint.sh
@@ -168,6 +168,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                             NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
                         done
                     fi
+
+                    if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
+                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                    fi
                 else
                     echo "running web-based installer on first connect!"
                 fi

--- a/20.0/fpm/entrypoint.sh
+++ b/20.0/fpm/entrypoint.sh
@@ -170,7 +170,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     fi
 
                     if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
-                        run_as "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                        run_as "/bin/sh ${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
                     fi
                 else
                     echo "running web-based installer on first connect!"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ One or more trusted domains can be set through environment variable, too. They w
 
 - `NEXTCLOUD_TRUSTED_DOMAINS` (not set by default) Optional space-separated list of domains
 
+To install custom apps, or execute occ commands, you can provide the path to a script that is run in the context of the www-data user.
+
+- `NEXTCLOUD_CUSTOM_INSTALL_SCRIPT` (not set by default) The path to a script that is mounted as volume.
+
 The install and update script is only triggered when a default command is used (`apache-foreground` or `php-fpm`). If you use a custom command you have to enable the install / update with
 
 - `NEXTCLOUD_UPDATE` (default: _0_)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -168,6 +168,10 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                             NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1))
                         done
                     fi
+
+                    if [ -n "${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT+x}" ]; then
+                        run_as "/bin/sh ${NEXTCLOUD_CUSTOM_INSTALL_SCRIPT}"
+                    fi
                 else
                     echo "running web-based installer on first connect!"
                 fi


### PR DESCRIPTION
Should fix issues
- https://github.com/nextcloud/docker/issues/820
- https://github.com/nextcloud/docker/issues/1203

This allows a custom script to be mounted as docker or kubernetes volume to be executed. This can be used to execute all kind of occ commands.

Alternative and more customizable to the PR https://github.com/nextcloud/docker/pull/1259