### PR TITLE
Update nginx.conf

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -124,6 +124,10 @@ http {
             fastcgi_pass php-handler;
             fastcgi_intercept_errors on;
             fastcgi_request_buffering off;
+            
+            # Prevent 504 gateway timeout
+            fastcgi_send_timeout 200;
+            fastcgi_read_timeout 200;
         }
 
         location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {


### PR DESCRIPTION
nginx times out when sign up is done, displaying the message "504 Gateway Timeout". This happens for the ssl one as well. I found that setting fastcgi timeout overcomes this issue.