### PR TITLE
Run "busybox --install -s" during image creation

### DIFF
--- a/17.0/apache/Dockerfile
+++ b/17.0/apache/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/17.0/fpm/Dockerfile
+++ b/17.0/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/18.0/apache/Dockerfile
+++ b/18.0/apache/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/18.0/fpm/Dockerfile
+++ b/18.0/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/19.0/apache/Dockerfile
+++ b/19.0/apache/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/19.0/fpm/Dockerfile
+++ b/19.0/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/20.0/apache/Dockerfile
+++ b/20.0/apache/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/20.0/fpm/Dockerfile
+++ b/20.0/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -11,6 +11,7 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    busybox --install -s; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/%%CRONTAB_INT%% * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 


### PR DESCRIPTION
I've made this change to avoid an error I get running these containers in production. THe issue I specifically see is that somewhere in Nextcloud, it calls the `ip` command, which is absent from these images. This change symlinks all `busybox` utils into place, and includes a symlink for the `ip` command.

Scope could be more limited to just include an `ip` symlink if required.