### PR TITLE
Add redis password to fix AUTH exception

### DIFF
--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/db.env
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/db.env
@@ -2,4 +2,3 @@ MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
 REDIS_HOST_PASSWORD=secretredispassword
-

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/db.env
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/db.env
@@ -1,3 +1,5 @@
 MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
+REDIS_HOST_PASSWORD=secretredispassword
+

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: redis-server --requirepass secretredispassword
     restart: always
 
   app:

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/db.env
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/db.env
@@ -2,4 +2,3 @@ MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
 REDIS_HOST_PASSWORD=secretredispassword
-

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/db.env
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/db.env
@@ -1,3 +1,5 @@
 MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
+REDIS_HOST_PASSWORD=secretredispassword
+

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: redis-server --requirepass secretredispassword
     restart: always
 
   app:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/db.env
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/db.env
@@ -2,4 +2,3 @@ MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
 REDIS_HOST_PASSWORD=secretredispassword
-

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/db.env
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/db.env
@@ -1,3 +1,5 @@
 MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
+REDIS_HOST_PASSWORD=secretredispassword
+

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: redis-server --requirepass secretredispassword
     restart: always
 
   app:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/db.env
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/db.env
@@ -2,4 +2,3 @@ MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
 REDIS_HOST_PASSWORD=secretredispassword
-

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/db.env
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/db.env
@@ -1,3 +1,5 @@
 MYSQL_PASSWORD=
 MYSQL_DATABASE=nextcloud
 MYSQL_USER=nextcloud
+REDIS_HOST_PASSWORD=secretredispassword
+

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   redis:
     image: redis:alpine
+    command: redis-server --requirepass secretredispassword
     restart: always
 
   app:


### PR DESCRIPTION
In the current version (nextcloud 19.04 and redis 6.08), a redis password is required for authentication.
This pull request sets a standard password.

Should affect the following bugs:

* #1275
* #1270
* #1179 

It works again for me and on my colleague's computer after the fix.