### PR TITLE
Set dbindex to separate data in a single Redis instance by environment variable

### DIFF
--- a/19.0/apache/config/redis.config.php
+++ b/19.0/apache/config/redis.config.php
@@ -14,4 +14,8 @@ if (getenv('REDIS_HOST')) {
   } elseif (getenv('REDIS_HOST')[0] != '/') {
     $CONFIG['redis']['port'] = 6379;
   }
+  
+  if (getenv('REDIS_DB_INDEX') !== false) {
+    $CONFIG['redis']['dbindex'] = getenv('REDIS_DB_INDEX');
+  }
 }

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If you want to use Redis you have to create a separate [Redis](https://hub.docke
 - `REDIS_HOST` (not set by default) Name of Redis container
 - `REDIS_HOST_PORT` (default: _6379_) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
 - `REDIS_HOST_PASSWORD` (not set by default) Redis password
+- `REDIS_DB_INDEX` (not set by default) Database (dbindex) in your Redis instance
 
 The use of Redis is recommended to prevent file locking problems. See the examples for further instructions.
 


### PR DESCRIPTION
Hi,

I want to share a single Redis instance and use it with several independent applications. Thus, I need a way to specify the dbindex. As I'm using a Docker deployment, I'd like to add the dbindex using an environment variable. For my Nextcloud 19 (i.e. "production") installation, I tested the following way. As I cannot test for different Nextcloud versions, I made this change only in the Nextcloud 19 folder. Perhaps the if-statement can be reused for different Nextcloud versions and can be copy/pasted.

Regards
Fabian