### PR TITLE
Use iconv from alpine edge repo to fix plugins breaking

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -34,6 +34,11 @@ RUN set -ex; \
         gmp-dev \
     ; \
     \
+    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+	    gnu-libiconv \
+	    php7-iconv \
+    ; \
+    \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install -j "$(nproc)" \
@@ -95,6 +100,7 @@ VOLUME /var/www/html
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
+ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
 
 RUN set -ex; \
     apk add --no-cache --virtual .fetch-deps \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -32,10 +32,7 @@ RUN set -ex; \
         imagemagick-dev \
         libwebp-dev \
         gmp-dev \
-    ; \
-    \
-    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
-	    gnu-libiconv \
+        gnu-libiconv \
 	    php7-iconv \
     ; \
     \


### PR DESCRIPTION
With this PR, gnu-libiconv and php7-iconv will be installed from the Alpine Linux Edge Community Repository instead of using the official repos. The reason for this is that the current iconv from the official repo doesn't work properly with iconv.

While yes, this is essentially a band aid fix, there seems to be no incentive for this to be fixed in Alpine directly anytime soon. So I think it's justified that we have to work around that as there are apps like the Mail app (v1.6.0 and up) that fully break if this iconv version is not installed.

Closes #1299