### PR TITLE
Environment variables in docker-compose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,14 @@ services:
       - 8080:80
     links:
       - db
+    restart: always
     volumes:
       - nextcloud:/var/www/html
-    restart: always
+    environment:
+      - MYSQL_PASSWORD=
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_HOST=db
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -285,9 +285,14 @@ services:
     image: nextcloud:fpm
     links:
       - db
+    restart: always
     volumes:
       - nextcloud:/var/www/html
-    restart: always
+    environment:
+      - MYSQL_PASSWORD=
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_HOST=db
 
   web:
     image: nginx


### PR DESCRIPTION
Docker-compose file in the example was missing database configuration environment variables of the app container, making the stack to use SQLite by default instead of the DB container.

Didn't add `NEXTCLOUD_ADMIN_*` variables since this addresses the DB being configured with SQLite. This still works setting up admin credentials on first NC run.