### PR TITLE
Update stable tag to 19.0.6

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-stable_channel='19.0.5'
+stable_channel='19.0.6'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
This updates the stable tag to 19.0.6.

Fixes #1323 