### PR TITLE
fix restart container issue

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -146,7 +146,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     install=true
                 fi
 
-                if [ "$install" = true ]; then
+                if [ ! -f "/var/www/html/config/config.php" ] && [ "$install" = true ]; then
                     echo "starting nextcloud installation"
                     max_retries=10
                     try=0


### PR DESCRIPTION
When restart nextcloud container The error occurred because /var/www/html/config folder already exist.