### PR TITLE
update stable tag to 20.0.4

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-stable_channel='19.0.6'
+stable_channel='20.0.4'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
as the official updater is now shipping 20.0.4 to all 19.0.6 users:
https://github.com/nextcloud/updater_server/commit/e332ce5a3c69cede68cd384d24009d6fb563b6bb