### PR TITLE
Add PHP bz2 extension

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -32,6 +32,7 @@ RUN set -ex; \
         imagemagick-dev \
         libwebp-dev \
         gmp-dev \
+        bzip2-dev \
     ; \
     \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
@@ -48,6 +49,7 @@ RUN set -ex; \
         pdo_pgsql \
         zip \
         gmp \
+        bz2 \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -37,6 +37,7 @@ RUN set -ex; \
         libzip-dev \
         libwebp-dev \
         libgmp-dev \
+        libbz2-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -56,6 +57,7 @@ RUN set -ex; \
         pdo_pgsql \
         zip \
         gmp \
+        bz2 \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately


### PR DESCRIPTION
Some Nextcloud apps require the bz2 PHP extension. This pull request adds bz2 into the official Docker image.