### PR TITLE
Add smbclient for External Storages support in Docker containers

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -5,6 +5,7 @@ RUN set -ex; \
     \
     apk add --no-cache \
         rsync \
+        samba-client \
     ; \
     \
     rm /var/spool/cron/crontabs/root; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,6 +8,7 @@ RUN set -ex; \
         rsync \
         bzip2 \
         busybox-static \
+        smbclient \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \


### PR DESCRIPTION
Quick PR that adds smbclient to the alpine and debian containers so that admins using the Docker containers can, with the right container configuration, use smbclient to mount external storages into Nextcloud without having to reconfigure their containers automatically.