### PR TITLE
Enable session locking for the redis session handler and use more sane locking configs.

### DIFF
--- a/19.0/apache/entrypoint.sh
+++ b/19.0/apache/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/19.0/fpm-alpine/entrypoint.sh
+++ b/19.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/19.0/fpm/entrypoint.sh
+++ b/19.0/fpm/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/20.0/apache/entrypoint.sh
+++ b/20.0/apache/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/20.0/fpm-alpine/entrypoint.sh
+++ b/20.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/20.0/fpm/entrypoint.sh
+++ b/20.0/fpm/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/21.0/apache/entrypoint.sh
+++ b/21.0/apache/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/21.0/fpm-alpine/entrypoint.sh
+++ b/21.0/fpm-alpine/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/21.0/fpm/entrypoint.sh
+++ b/21.0/fpm/entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,6 +69,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             else
                 echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
+            echo "redis.session.locking_enabled = 1"
+            echo "redis.session.lock_retries = -1"
+            # redis.session.lock_wait_time is specified in microseconds.
+            # Wait 10ms before retrying the lock rather than the default 2ms.
+            echo "redis.session.lock_wait_time = 10000"
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 


### PR DESCRIPTION
By default, the Redis session handler does *not* lock sessions while manipulating them.  This can be extremely problematic for applications that might fire multiple requests at the server simultaneously (ie background XHR tasks, images or other assets that are served via PHP, etc) as the session data is written to the handler as a single serialized value, and lack of locking can lead to race conditions where old data might be written back to a session.  I have seen this firsthand with the Talk/Spreed app while using this Docker image along with Redis.  When switching back and forth between conversations, you can sometimes be redirected to the spreed not-found page.  This is due to the multiple XHR requests being run/cancelled/etc, sometimes leading to newer room data in the session being overwritten by older data.  This update fixes the Redis session integration to ensure that sessions are properly locked so that data corruption does not occur.  With these settings, I no longer run into issues with Talk.

I am working on a separate PR for the phpredis project to try to implement some better default locking logic and fix a bug when it can't acquire the lock.  As it stands right now, if you enable locking, it will only attempt to acquire the lock for 20ms, then it will continue - just without the lock.  The session data will be read and provided to the running application.  When the application then attempts to write/close the session, phpredis will fail spectacularly if it failed to acquire the lock during session initialization.  Setting the retries to -1 allows phpredis to try forever to obtain the session lock, which is exactly the same behavior as the default `files` session handler.

References:
https://github.com/nextcloud/spreed/issues/4670
https://github.com/nextcloud/server/pull/1936#issuecomment-282008712
https://github.com/phpredis/phpredis/issues/1411
https://github.com/phpredis/phpredis/issues/1422