### PR TITLE
Changing of nginx reverse proxy config

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/web/nginx.conf
@@ -78,11 +78,11 @@ http {
         #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
 
         location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         # set max upload size

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -78,11 +78,11 @@ http {
         #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
 
         location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         # set max upload size

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -78,11 +78,11 @@ http {
         #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
 
         location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $scheme://$host/remote.php/dav;
         }
 
         # set max upload size


### PR DESCRIPTION
Changing of nginx reverse proxy config to avoid warnings on **Admin >> Settings** page 
```
    Your web server is not properly set up to resolve “/.well-known/caldav”. Further information can be found in the documentation
    Your web server is not properly set up to resolve “/.well-known/carddav”. Further information can be found in the documentation
```
