### PR TITLE
Fixed invalid `PHP_INI_MEMORY_LIMIT` variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ To use an external OpenStack Swift object store as primary storage, set the foll
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#openstack-swift) for more information.
 
 To customize other PHP limits you can simply change the following variables:
-- `PHP_INI_MEMORY_LIMIT` (default `512M`) This sets the maximum amount of memory in bytes that a script is allowed to allocate. This is meant to help prevent poorly written scripts from eating up all available memory but it can prevent normal operation if set too tight.
+- `PHP_MEMORY_LIMIT` (default `512M`) This sets the maximum amount of memory in bytes that a script is allowed to allocate. This is meant to help prevent poorly written scripts from eating up all available memory but it can prevent normal operation if set too tight.
 - `PHP_UPLOAD_LIMIT` (default `512M`) This sets the upload limit (`post_max_size` and `upload_max_filesize`) for big files. Note that you may have to change other limits depending on your client, webserver or operating system. Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/big_file_upload_configuration.html) for more information.
 
 


### PR DESCRIPTION
There is not PHP**_INI**_MEMORY_LIMIT variable used in code. So, it was documentation mistake, i guess