### PR TITLE
WIP: Adding missing dependency for SVG files

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -85,6 +85,7 @@ RUN set -ex; \
         | xargs -rt apt-mark manual; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    apt-get install -y --no-install-recommends libmagickcore-6.q16-6-extra; \
     rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings


### PR DESCRIPTION
Possible fix for #1414 with the addition of a missing package.
This only fixes the issue for Debian based images.
Tested with NC21 apache variant.

TODO: alpine variants