### PR TITLE
Add "legacy_auth" option for S3 object stores

### DIFF
--- a/.config/s3.config.php
+++ b/.config/s3.config.php
@@ -18,7 +18,7 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
         // required for older protocol versions
         'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )

--- a/.config/s3.config.php
+++ b/.config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/19.0/apache/config/s3.config.php
+++ b/19.0/apache/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/19.0/fpm-alpine/config/s3.config.php
+++ b/19.0/fpm-alpine/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/19.0/fpm/config/s3.config.php
+++ b/19.0/fpm/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/20.0/apache/config/s3.config.php
+++ b/20.0/apache/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/20.0/fpm-alpine/config/s3.config.php
+++ b/20.0/fpm-alpine/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/20.0/fpm/config/s3.config.php
+++ b/20.0/fpm/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/21.0/apache/config/s3.config.php
+++ b/21.0/apache/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/21.0/fpm-alpine/config/s3.config.php
+++ b/21.0/fpm-alpine/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/21.0/fpm/config/s3.config.php
+++ b/21.0/fpm/config/s3.config.php
@@ -2,6 +2,7 @@
 if (getenv('OBJECTSTORE_S3_BUCKET')) {
   $use_ssl = getenv('OBJECTSTORE_S3_SSL');
   $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
+  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
   $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
   $CONFIG = array(
     'objectstore' => array(
@@ -17,7 +18,9 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
         'autocreate' => (strtolower($autocreate) === 'false' || $autocreate == false) ? false : true,
         'use_ssl' => (strtolower($use_ssl) === 'false' || $use_ssl == false) ? false : true,
         // required for some non Amazon S3 implementations
-        'use_path_style' => $use_path == true && strtolower($use_path) !== 'false'
+		'use_path_style' => $use_path == true && strtolower($use_path) !== 'false',
+        // required for older protocol versions
+        'legacy_auth' => $use_legacyauth == true && strtolower($use_legacyauth) !== 'false'
       )
     )
   );

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To use an external S3 compatible object store as primary storage, set the follow
 - `OBJECTSTORE_S3_SSL` (default: `true`): Whether or not SSL/TLS should be used to communicate with object storage server
 - `OBJECTSTORE_S3_REGION`: The region that the S3 bucket resides in.
 - `OBJECTSTORE_S3_USEPATH_STYLE` (default: `false`): Not required for AWS S3
+- `OBJECTSTORE_S3_LEGACYAUTH` (default: `false`): Not required for AWS S3
 - `OBJECTSTORE_S3_OBJECT_PREFIX` (default: `urn:oid:`): Prefix to prepend to the fileid
 - `OBJECTSTORE_S3_AUTOCREATE` (default: `true`): Create the container if it does not exist
 


### PR DESCRIPTION
Because of some MinIO issues with kubernetes, nextcloud and MinIO I did switch to the "legacy_auth" protocoll, see: 
https://github.com/nextcloud/server/blob/137636b651168712ee88beaa8ac0483e38bf42b4/lib/private/Files/ObjectStore/S3ConnectionTrait.php#L128

I noticed that this setting was missing at the s3 config as well.