### PR TITLE
Explicitly set locale settings

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -14,6 +14,10 @@ RUN set -ex; \
     mkdir -p /var/spool/cron/crontabs; \
     echo '*/%%CRONTAB_INT%% * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
+# setting proper locale to prevent encoding issues
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
 ENV PHP_MEMORY_LIMIT 512M


### PR DESCRIPTION
As of right now, this only works on non-alpine images, as `locale` is not yet supported by Alpine Linux. Therefore, only changes to the debian template have been made. There are some workarounds for Alpine as well (as seen [here](https://github.com/gliderlabs/docker-alpine/issues/144#issuecomment-339906345)), but this seems a little too hacky for me and maybe even unnecessary. Would be nice if someone with more experience could comment on that.

Fixes #721 