### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ secrets:
     file: ./postgres_user.txt # put postgresql username to this file
 ```
 
-Currently, this is only supported for `NEXTCLOUD_ADMIN_PASSWORD`, `NEXTCLOUD_ADMIN_USER`, `MYSQL_DB`, `MYSQL_PASSWORD`, `MYSQL_USER`, `POSTGRES_DB`, `POSTGRES_PASSWORD`, `POSTGRES_USER` and `REDIS_HOST_PASSWORD`.
+Currently, this is only supported for `NEXTCLOUD_ADMIN_PASSWORD`, `NEXTCLOUD_ADMIN_USER`, `MYSQL_DATABASE`, `MYSQL_PASSWORD`, `MYSQL_USER`, `POSTGRES_DB`, `POSTGRES_PASSWORD`, `POSTGRES_USER` and `REDIS_HOST_PASSWORD`.
 
 # Make your Nextcloud available from the internet
 Until here, your Nextcloud is just available from your docker host. If you want your Nextcloud available from the internet adding SSL encryption is mandatory.


### PR DESCRIPTION
The environment variable for MYSQL_DATABASE was named MYSQL_DB in chapter "Docker Secrets".

The typo probably happened because of inconsistent naming of MYSQL_DATABSE vs POSTGRES_DB.