### PR TITLE
cron and redis fixes for running with non-root UID

### DIFF
--- a/20/apache/Dockerfile
+++ b/20/apache/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/apache/Dockerfile
+++ b/20/apache/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/apache/cron.sh
+++ b/20/apache/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/20/fpm-alpine/Dockerfile
+++ b/20/fpm-alpine/Dockerfile
@@ -8,8 +8,7 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm /var/spool/cron/crontabs/root
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/fpm-alpine/Dockerfile
+++ b/20/fpm-alpine/Dockerfile
@@ -8,7 +8,9 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root
+    rm /var/spool/cron/crontabs/root; \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/fpm-alpine/cron.sh
+++ b/20/fpm-alpine/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/20/fpm/Dockerfile
+++ b/20/fpm/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/fpm/Dockerfile
+++ b/20/fpm/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/20/fpm/cron.sh
+++ b/20/fpm/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/21/apache/Dockerfile
+++ b/21/apache/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/apache/Dockerfile
+++ b/21/apache/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/apache/cron.sh
+++ b/21/apache/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/21/fpm-alpine/Dockerfile
+++ b/21/fpm-alpine/Dockerfile
@@ -8,8 +8,7 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm /var/spool/cron/crontabs/root
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/fpm-alpine/Dockerfile
+++ b/21/fpm-alpine/Dockerfile
@@ -8,7 +8,9 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root
+    rm /var/spool/cron/crontabs/root; \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/fpm-alpine/cron.sh
+++ b/21/fpm-alpine/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/21/fpm/Dockerfile
+++ b/21/fpm/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/fpm/Dockerfile
+++ b/21/fpm/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/21/fpm/cron.sh
+++ b/21/fpm/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/22/apache/Dockerfile
+++ b/22/apache/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/apache/Dockerfile
+++ b/22/apache/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/apache/cron.sh
+++ b/22/apache/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/22/fpm-alpine/Dockerfile
+++ b/22/fpm-alpine/Dockerfile
@@ -8,8 +8,7 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm /var/spool/cron/crontabs/root
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/fpm-alpine/Dockerfile
+++ b/22/fpm-alpine/Dockerfile
@@ -8,7 +8,9 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root
+    rm /var/spool/cron/crontabs/root; \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/fpm-alpine/cron.sh
+++ b/22/fpm-alpine/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/22/fpm/Dockerfile
+++ b/22/fpm/Dockerfile
@@ -11,7 +11,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/fpm/Dockerfile
+++ b/22/fpm/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/22/fpm/cron.sh
+++ b/22/fpm/cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep 5m;
+done

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,8 +7,7 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root; \
-    echo '*/%%CRONTAB_INT%% * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm /var/spool/cron/crontabs/root
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,7 +7,9 @@ RUN set -ex; \
         rsync \
     ; \
     \
-    rm /var/spool/cron/crontabs/root
+    rm /var/spool/cron/crontabs/root; \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -10,7 +10,10 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    touch /usr/local/etc/php/conf.d/redis-session.ini; \
+    chmod o+rw /usr/local/etc/php/conf.d/redis-session.ini;
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -10,10 +10,7 @@ RUN set -ex; \
         busybox-static \
         libldap-common \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    mkdir -p /var/spool/cron/crontabs; \
-    echo '*/%%CRONTAB_INT%% * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
+    rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html

--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+while [ 1 ]; do
+    (php -f /var/www/html/cron.php &);
+    sleep %%CRONTAB_INT%%m;
+done

--- a/update.sh
+++ b/update.sh
@@ -111,7 +111,6 @@ function create_variant() {
 		s/%%MEMCACHED_VERSION%%/'"${pecl_versions[memcached]}"'/g;
 		s/%%REDIS_VERSION%%/'"${pecl_versions[redis]}"'/g;
 		s/%%IMAGICK_VERSION%%/'"${pecl_versions[imagick]}"'/g;
-		s/%%CRONTAB_INT%%/'"$crontabInt"'/g;
 	' "$dir/Dockerfile"
 
 	case "$phpVersion" in
@@ -132,6 +131,10 @@ function create_variant() {
 	for name in entrypoint cron; do
 		cp "docker-$name.sh" "$dir/$name.sh"
 	done
+	# Replace the variable.
+	sed -ri -e '
+		s/%%CRONTAB_INT%%/'"$crontabInt"'/g;
+	' "$dir/cron.sh"
 
 	# Copy the upgrade.exclude
 	cp upgrade.exclude "$dir/"


### PR DESCRIPTION
When not running as 'www-data', the redis and cron functionality (as shown in examples such as ".examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml") break. These commits fix these issues. 

Partial fix for #359

Possible supplement to #1278.