### PR TITLE
update nginx.conf examples to match current NC20 official documentation related to /.well-known

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -63,21 +63,22 @@ http {
             access_log off;
         }
 
-        # The following 2 rules are only needed for the user_webfinger app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-        #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-        # The following rule is only needed for the Social app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-        location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
-        }
-
-        location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+        # Make a regex exception for `/.well-known` so that clients can still
+        # access it despite the existence of the regex rule
+        # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+        # for `/.well-known`.
+        location ^~ /.well-known {
+            # The following 6 rules are borrowed from `.htaccess`
+    
+            rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+            rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+            rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+            rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+    
+            location = /.well-known/carddav     { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+    
+            try_files $uri $uri/ =404;
         }
 
         # set max upload size

--- a/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
@@ -63,21 +63,22 @@ http {
             access_log off;
         }
 
-        # The following 2 rules are only needed for the user_webfinger app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-        #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-        # The following rule is only needed for the Social app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-        location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
-        }
-
-        location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+        # Make a regex exception for `/.well-known` so that clients can still
+        # access it despite the existence of the regex rule
+        # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+        # for `/.well-known`.
+        location ^~ /.well-known {
+            # The following 6 rules are borrowed from `.htaccess`
+    
+            rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+            rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+            rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+            rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+    
+            location = /.well-known/carddav     { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+    
+            try_files $uri $uri/ =404;
         }
 
         # set max upload size

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -68,21 +68,22 @@ http {
             access_log off;
         }
 
-        # The following 2 rules are only needed for the user_webfinger app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-        #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-        # The following rule is only needed for the Social app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-        location = /.well-known/carddav {
-            return 301 $scheme://$host/remote.php/dav;
-        }
-
-        location = /.well-known/caldav {
-            return 301 $scheme://$host/remote.php/dav;
+        # Make a regex exception for `/.well-known` so that clients can still
+        # access it despite the existence of the regex rule
+        # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+        # for `/.well-known`.
+        location ^~ /.well-known {
+            # The following 6 rules are borrowed from `.htaccess`
+    
+            rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+            rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+            rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+            rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+    
+            location = /.well-known/carddav     { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+    
+            try_files $uri $uri/ =404;
         }
 
         # set max upload size

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -68,21 +68,22 @@ http {
             access_log off;
         }
 
-        # The following 2 rules are only needed for the user_webfinger app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-        #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-        # The following rule is only needed for the Social app.
-        # Uncomment it if you're planning to use this app.
-        #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-        location = /.well-known/carddav {
-            return 301 $scheme://$host/remote.php/dav;
-        }
-
-        location = /.well-known/caldav {
-            return 301 $scheme://$host/remote.php/dav;
+        # Make a regex exception for `/.well-known` so that clients can still
+        # access it despite the existence of the regex rule
+        # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+        # for `/.well-known`.
+        location ^~ /.well-known {
+            # The following 6 rules are borrowed from `.htaccess`
+    
+            rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+            rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+            rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+            rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+    
+            location = /.well-known/carddav     { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+    
+            try_files $uri $uri/ =404;
         }
 
         # set max upload size


### PR DESCRIPTION
The official documentation is mentioning a different configuration related to the /.well-known section.
This PR aims at aligning the examples files with the documentation on this specific point.

It seems that there are other parts that could be updated, but I am afraid to break things as I am not a specialist of NGINX config.

If anything need to be reworked, just let me know.