### PR TITLE
added ghostscript for pdf preview

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -32,6 +32,7 @@ RUN set -ex; \
         imagemagick-dev \
         libwebp-dev \
         gmp-dev \
+        ghostscript \
     ; \
     \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -39,6 +39,7 @@ RUN set -ex; \
         libzip-dev \
         libwebp-dev \
         libgmp-dev \
+        ghostscript \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \


### PR DESCRIPTION
If you enable pdf preview in the preview generator ghostscript binary is required.
Closes #1460

Signed-off-by: Jan Lahmer <jan@lahmer.eu>