### PR TITLE
Fix broken smtp.config.php file

### DIFF
--- a/21.0/fpm-alpine/config/smtp.config.php
+++ b/21.0/fpm-alpine/config/smtp.config.php
@@ -1,5 +1,5 @@
 <?php
-if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+if (getenv('SMTP_HOST')) {
   $CONFIG = array (
     'mail_smtpmode' => 'smtp',
     'mail_smtphost' => getenv('SMTP_HOST'),
@@ -9,7 +9,11 @@ if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN'))
     'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
     'mail_smtpname' => getenv('SMTP_NAME') ?: '',
     'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
-    'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
-    'mail_domain' => getenv('MAIL_DOMAIN'),
   );
+  if (getenv('MAIL_FROM_ADDRESS')) {
+    $CONFIG['mail_from_address'] = getenv('MAIL_FROM_ADDRESS');
+  }
+  if (getenv('MAIL_DOMAIN')) {
+    $CONFIG['mail_domain'] = getenv('MAIL_DOMAIN');
+  }
 }


### PR DESCRIPTION
The current `smtp.config.php` file does not work as advertised in the documentation. Both `MAIL_FROM_ADDRESS` and `MAIL_DOMAIN` should be optional as the Nextcloud instance may use multiple _from addresses_ like no-reply@example.com or passwordreset-no-reply@example.com (or similar). It may also just use the domain name from the instance instead of a configured one.

I tested this PR on NC 21 as I don't have access to the previous versions at the moment. I propose to leave NC 19 annd 20 as they are and to continue with this `smtp.config.php` from version 21 forward.