### PR TITLE
Added fetching autoconfig data from Docker secrets

### DIFF
--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -13,11 +13,25 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
     $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
     $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'mysql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
+    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
 } elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG['dbtype'] = 'pgsql';
     $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
     $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
     $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'pgsql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
     $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
     $autoconfig_enabled = true;
 }


### PR DESCRIPTION
This should solve https://github.com/nextcloud/docker/issues/1148

This is my first PR. I'm not very familiar with Docker, however, I hope that this solves the issue.
I changed only `.config/autoconfig.php `, as far as I can understand these changes should propagate to, say, `21.0/apache/config/autoconfig.php` automatically.

Please correct me if I'm wrong.

Another question to consider is the security of `trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));`. Theoretically, it is possible to specify any file, however, the very same approach is used in `entrypoint.sh`. Both the installation script and Docker secrets should be controlled by a privileged user. I see no issues with this, however, I'm not a security expert and thus I request a second opinion.