### PR TITLE
Added fetching autoconfig data from Docker secrets

### DIFF
--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -6,13 +6,6 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbtype'] = 'sqlite';
     $AUTOCONFIG['dbname'] = getenv('SQLITE_DATABASE');
     $autoconfig_enabled = true;
-} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'mysql';
-    $AUTOCONFIG['dbname'] = getenv('MYSQL_DATABASE');
-    $AUTOCONFIG['dbuser'] = getenv('MYSQL_USER');
-    $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
-    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
-    $autoconfig_enabled = true;
 } elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
     $AUTOCONFIG['dbtype'] = 'mysql';
     $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
@@ -20,18 +13,25 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
     $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
     $autoconfig_enabled = true;
-} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'pgsql';
-    $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
-    $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
-    $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
-    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
+} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'mysql';
+    $AUTOCONFIG['dbname'] = getenv('MYSQL_DATABASE');
+    $AUTOCONFIG['dbuser'] = getenv('MYSQL_USER');
+    $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
+    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
     $autoconfig_enabled = true;
 } elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG['dbtype'] = 'pgsql';
     $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
     $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
     $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
+    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'pgsql';
+    $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
+    $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
+    $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
     $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
     $autoconfig_enabled = true;
 }

--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -13,11 +13,25 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
     $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
     $autoconfig_enabled = true;
+} elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'mysql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
+    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
+    $autoconfig_enabled = true;
 } elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG['dbtype'] = 'pgsql';
     $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
     $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
     $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
+    $autoconfig_enabled = true;
+} elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
+    $AUTOCONFIG['dbtype'] = 'pgsql';
+    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
+    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
+    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
     $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
     $autoconfig_enabled = true;
 }

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ __PostgreSQL__:
 - `POSTGRES_PASSWORD` Password for the database user using postgres.
 - `POSTGRES_HOST` Hostname of the database server using postgres.
 
-If you set any values, they will not be asked in the install page on first run. With a complete configuration by using all variables for your database type, you can additionally configure your Nextcloud instance by setting admin user and password (only works if you set both):
+As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to the previously listed environment variables, causing the initialization script to load the values for those variables from files present in the container. See [Docker secrets](#docker=secrets) section below.
+
+If you set any group of values (i.e. all of `MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`), they will not be asked in the install page on first run. With a complete configuration by using all variables for your database type, you can additionally configure your Nextcloud instance by setting admin user and password (only works if you set both):
 
 - `NEXTCLOUD_ADMIN_USER` Name of the Nextcloud admin user.
 - `NEXTCLOUD_ADMIN_PASSWORD` Password for the Nextcloud admin user.
@@ -374,6 +376,8 @@ secrets:
 ```
 
 Currently, this is only supported for `NEXTCLOUD_ADMIN_PASSWORD`, `NEXTCLOUD_ADMIN_USER`, `MYSQL_DATABASE`, `MYSQL_PASSWORD`, `MYSQL_USER`, `POSTGRES_DB`, `POSTGRES_PASSWORD`, `POSTGRES_USER` and `REDIS_HOST_PASSWORD`.
+
+If you set any group of values (i.e. all of `MYSQL_DATABASE_FILE`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`, `MYSQL_HOST`), the script will not use the corresponding group of environment variables (`MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`)
 
 # Make your Nextcloud available from the internet
 Until here, your Nextcloud is just available from your docker host. If you want your Nextcloud available from the internet adding SSL encryption is mandatory.


### PR DESCRIPTION
Signed-off-by: Simon Tushev <tushev@users.noreply.github.com>

This should solve #1148

This is my first PR. I'm not very familiar with Docker, however, I hope that this solves the issue.
I changed only `.config/autoconfig.php` , as far as I can understand these changes should propagate to, say, `21.0/apache/config/autoconfig.php` automatically.

Please correct me if I'm wrong.

Another question to consider is the security of `trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));`. Theoretically, it is possible to specify any file, however, the very same approach is used in `entrypoint.sh`. Both the installation script and Docker secrets should be controlled by a privileged user. I see no issues with this, however, I'm not a security expert and thus I request a second opinion.