### PR TITLE
don't expose insecure ports to the public

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: nextcloud:apache
     restart: always
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     volumes:
       - nextcloud:/var/www/html
     environment:

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     build: ./web
     restart: always
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     volumes:
       - nextcloud:/var/www/html:ro
     depends_on:

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: nextcloud:apache
     restart: always
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     volumes:
       - nextcloud:/var/www/html
     environment:

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     build: ./web
     restart: always
     ports:
-      - 8080:80
+      - 127.0.0.1:8080:80
     volumes:
       - nextcloud:/var/www/html:ro
     depends_on:


### PR DESCRIPTION
if you do not specify 127.0.0.1 in the port mapping, docker will change iptables settings, and expose the services to the public internet even with a firewall enabled.

https://dev.to/kovah/be-careful-with-docker-ports-3pih

i didn't change secure examples because you probably won't be using a reverse proxy.