### PR TITLE
Update stable tag to 21.0.3

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-stable_channel='20.0.11'
+stable_channel='21.0.3'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
The official updater now rolls out 21.0.3 to all 20.0.11 users, so do the same for docker users