### PR TITLE
Enhancement: Allow hostnames in trusted proxies

### DIFF
--- a/.config/reverse-proxy.config.php
+++ b/.config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/20/apache/config/reverse-proxy.config.php
+++ b/20/apache/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/20/fpm-alpine/config/reverse-proxy.config.php
+++ b/20/fpm-alpine/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/20/fpm/config/reverse-proxy.config.php
+++ b/20/fpm/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/21/apache/config/reverse-proxy.config.php
+++ b/21/apache/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/21/fpm-alpine/config/reverse-proxy.config.php
+++ b/21/fpm-alpine/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/21/fpm/config/reverse-proxy.config.php
+++ b/21/fpm/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/22/apache/config/reverse-proxy.config.php
+++ b/22/apache/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/22/fpm-alpine/config/reverse-proxy.config.php
+++ b/22/fpm-alpine/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }

--- a/22/fpm/config/reverse-proxy.config.php
+++ b/22/fpm/config/reverse-proxy.config.php
@@ -21,5 +21,5 @@ if ($overwriteCondAddr) {
 
 $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
-  $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
+  $CONFIG['trusted_proxies'] = array_values(array_unique(array_map('gethostbyname', array_filter(explode(' ', $trustedProxies)))));
 }


### PR DESCRIPTION
Steps for convertion:

1. explode: Split $trustedProxies
2. array_filter: Clean empty arrays (dublicate spaces)
3. array_map-gethostbyname: convert hostname to ip, if false, return source value
4. array_unique: remove dublicate ips
5. array_values: reindex array keys