### PR TITLE
update permissions on upgrade

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -109,6 +109,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             fi
         done
         rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        if [ "$(id -u)" = 0 ]; then
+            chown -R www-data:root /var/www/html
+        fi
         echo "Initializing finished"
 
         #install

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -110,7 +110,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         done
         rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
         if [ "$(id -u)" = 0 ]; then
-            chown -R www-data:root /var/www/html
+            chown www-data:root /var/www/html/*
         fi
         echo "Initializing finished"
 


### PR DESCRIPTION
This should fix an intermittent issue where the permissions are not properly updated on startup

```
Initializing nextcloud 21.0.3.1 ...
25/08/2021 09:39:31 Initializing finished
25/08/2021 09:39:31 New nextcloud instance
25/08/2021 09:39:31 Installing with MySQL database
25/08/2021 09:39:31 starting nextcloud installation
25/08/2021 09:39:31 Can't create or write into the data directory /var/www/html/data
25/08/2021 09:39:31 retrying install...
```

If required I can also clean up the rsync options as this chown should remove the need for rsync to manage them

