### PR TITLE
Switch to new nginx companion registry.

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - proxy-tier
 
   letsencrypt-companion:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion
     restart: always
     volumes:
       - certs:/etc/nginx/certs


### PR DESCRIPTION
As stated in https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion/ the the project has moved to a new registry and therefore that should be used instead.