### PR TITLE
also install libldap-common to get a valid /etc/ldap/ldap.conf file

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -29,6 +29,7 @@ RUN set -ex; \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \
+        libldap-common \
         libldap2-dev \
         libmcrypt-dev \
         libmemcached-dev \


### PR DESCRIPTION
related to https://github.com/nextcloud/docker/issues/1572

Signed-off-by: Sebastian BERTHOLD <5272331+sleif@users.noreply.github.com>