### PR TITLE
update stable to 21.0.5

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-stable_channel='21.0.4'
+stable_channel='21.0.5'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
the official updater rolls out 21.0.5 to all 21 users now, so do the same with docker stable tag