### PR TITLE
Add libldap-common as runtime dependency, not build dependency

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,6 +8,7 @@ RUN set -ex; \
         rsync \
         bzip2 \
         busybox-static \
+        libldap-common \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     \
@@ -29,7 +30,6 @@ RUN set -ex; \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \
-        libldap-common \
         libldap2-dev \
         libmcrypt-dev \
         libmemcached-dev \


### PR DESCRIPTION
Fixes #1572 