### PR TITLE
Upgrade to 22.2.0

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-stable_channel='21.0.5'
+stable_channel='22.2.0'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Implementing the upgrade to 22.2.0 from https://github.com/nextcloud/updater_server/commit/87845a5b5e51c1b3920dc10291f65c0859667a78 in the docker-version.

Signed-off-by: Thomas131 <t@t131.us.to>

@J0WI - pls review (or commit yourself)