### PR TITLE
Disable security labels on the proxy and letsencrypt companion containers

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     networks:
       - proxy-tier
+    security_opt:
+      - label:disable
 
   letsencrypt-companion:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -75,7 +77,9 @@ services:
       - proxy-tier
     depends_on:
       - proxy
-
+    security_opt:
+      - label:disable
+      
 # self signed
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - proxy
     security_opt:
       - label:disable
+      
 # self signed
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -70,6 +70,8 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     networks:
       - proxy-tier
+    security_opt:
+      - label:disable
 
   letsencrypt-companion:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -84,7 +86,8 @@ services:
       - proxy-tier
     depends_on:
       - proxy
-
+    security_opt:
+      - label:disable
 # self signed
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     networks:
       - proxy-tier
+    security_opt:
+      - label:disable
 
   letsencrypt-companion:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -72,7 +74,9 @@ services:
       - proxy-tier
     depends_on:
       - proxy
-
+    security_opt:
+      - label:disable
+      
 # self signed
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     networks:
       - proxy-tier
+    security_opt:
+      - label:disable
 
   letsencrypt-companion:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -81,7 +83,9 @@ services:
       - proxy-tier
     depends_on:
       - proxy
-
+    security_opt:
+      - label:disable
+      
 # self signed
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl


### PR DESCRIPTION
The security lables needs to be disabled, otherwise SELinux will deny access to the docker socket.
https://access.redhat.com/solutions/4344161