### PR TITLE
Add OVERWRITECLIURL env var

### DIFF
--- a/.config/reverse-proxy.config.php
+++ b/.config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/20/apache/config/reverse-proxy.config.php
+++ b/20/apache/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/20/fpm-alpine/config/reverse-proxy.config.php
+++ b/20/fpm-alpine/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/20/fpm/config/reverse-proxy.config.php
+++ b/20/fpm/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/21/apache/config/reverse-proxy.config.php
+++ b/21/apache/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/21/fpm-alpine/config/reverse-proxy.config.php
+++ b/21/fpm-alpine/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/21/fpm/config/reverse-proxy.config.php
+++ b/21/fpm/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/22/apache/config/reverse-proxy.config.php
+++ b/22/apache/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/22/fpm-alpine/config/reverse-proxy.config.php
+++ b/22/fpm-alpine/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/22/fpm/config/reverse-proxy.config.php
+++ b/22/fpm/config/reverse-proxy.config.php
@@ -9,6 +9,11 @@ if ($overwriteProtocol) {
   $CONFIG['overwriteprotocol'] = $overwriteProtocol;
 }
 
+$overwriteCliUrl = getenv('OVERWRITECLIURL');
+if ($overwriteCliUrl) {
+  $CONFIG['overwrite.cli.url'] = $overwriteCliUrl;
+}
+
 $overwriteWebRoot = getenv('OVERWRITEWEBROOT');
 if ($overwriteWebRoot) {
   $CONFIG['overwritewebroot'] = $overwriteWebRoot;

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ If the `TRUSTED_PROXIES` approach does not work for you, try using fixed values 
 
 - `OVERWRITEHOST` (empty by default): Set the hostname of the proxy. Can also specify a port.
 - `OVERWRITEPROTOCOL` (empty by default): Set the protocol of the proxy, http or https.
+- `OVERWRITECLIURL` (empty by default): Set the cli url of the proxy (e.g. https://mydnsname.example.com)
 - `OVERWRITEWEBROOT` (empty by default): Set the absolute path of the proxy.
 - `OVERWRITECONDADDR` (empty by default): Regex to overwrite the values dependent on the remote address.
 


### PR DESCRIPTION
Currently this option gets generated incorrectly. It's set to "localhost" in the configuration file.
This PR exposes the setting through an environment variable making it possible to be configured properly.