### PR TITLE
Update to work with MariaDB >= 10.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ volumes:
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --skip-innodb-read-only-compressed
     volumes:
       - db:/var/lib/mysql
     environment:
@@ -274,9 +274,9 @@ volumes:
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --skip-innodb-read-only-compressed
     volumes:
       - db:/var/lib/mysql
     environment:


### PR DESCRIPTION
Nextcloud is incompatible with the new innodb-read-only-compressed feature introduced with MariaDB 10.6

See:
* https://mariadb.com/docs/reference/mdb/cli/mariadbd/innodb-read-only-compressed/
* https://techoverflow.net/2021/08/17/how-to-fix-nextcloud-4047-innodb-refuses-to-write-tables-with-row_formatcompressed-or-key_block_size/
* https://help.nextcloud.com/t/update-to-next-cloud-21-0-2-has-get-an-error/117028