### PR TITLE
run bash via env command

### DIFF
--- a/.travis/test-example-dockerfiles.sh
+++ b/.travis/test-example-dockerfiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 image="$1"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 stable_channel='22.2.3'

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 declare -A php_version=(


### PR DESCRIPTION
`#!/usr/bin/env` searches `PATH` for `bash`, and `bash` is not always in `/bin`