### PR TITLE
Update Nginx-Proxy Docker repository

### DIFF
--- a/.examples/README.md
+++ b/.examples/README.md
@@ -91,7 +91,7 @@ If you want to update your installation to a newer version of nextcloud, repeat 
 The nginx proxy adds a proxy layer between nextcloud and the internet. The proxy is designed to serve multiple sites on the same host machine.
 
 The advantage in adding this layer is the ability to add a container for [Let's Encrypt](https://letsencrypt.org/) certificate handling.
-This combination of the [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) and [jrcs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) containers creates a fully automated https encryption of the nextcloud installation without worrying about certificate generation, validation or renewal.
+This combination of the [nginxproxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) and [nginxproxy/acme-companion](https://github.com/nginx-proxy/acme-companion) containers creates a fully automated https encryption of the nextcloud installation without worrying about certificate generation, validation or renewal.
 
 **This setup only works with a valid domain name on a server that is reachable from the internet.**
 

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -52,8 +52,6 @@ services:
     ports:
       - 80:80
       - 443:443
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -63,13 +61,13 @@ services:
       - proxy-tier
 
   letsencrypt-companion:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion
     restart: always
+    volumes_from:
+      - proxy
     volumes:
-      - certs:/etc/nginx/certs
+      - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
-      - vhost.d:/etc/nginx/vhost.d
-      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -61,8 +61,6 @@ services:
     ports:
       - 80:80
       - 443:443
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -72,13 +70,13 @@ services:
       - proxy-tier
 
   letsencrypt-companion:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion
     restart: always
+    volumes_from:
+      - proxy
     volumes:
-      - certs:/etc/nginx/certs
+      - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
-      - vhost.d:/etc/nginx/vhost.d
-      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -49,8 +49,6 @@ services:
     ports:
       - 80:80
       - 443:443
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -60,13 +58,13 @@ services:
       - proxy-tier
 
   letsencrypt-companion:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion
     restart: always
+    volumes_from:
+      - proxy
     volumes:
-      - certs:/etc/nginx/certs
+      - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
-      - vhost.d:/etc/nginx/vhost.d
-      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -58,8 +58,6 @@ services:
     ports:
       - 80:80
       - 443:443
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -71,11 +69,11 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
+    volumes_from:
+      - proxy
     volumes:
-      - certs:/etc/nginx/certs
+      - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
-      - vhost.d:/etc/nginx/vhost.d
-      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf


### PR DESCRIPTION
The nginx-proxy repo moved to https://github.com/nginx-proxy/ as well as the docker repository to https://hub.docker.com/u/nginxproxy
I also switched the linking from the label to the more elegant volumes_from way.