### PR TITLE
Add link to nginx configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 
 ## Using the fpm image
-To use the fpm image, you need an additional web server that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker-compose` file). In both cases you don't want to map the fpm port to your host.
+To use the fpm image, you need an additional web server, such as [nginx](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html), that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker-compose` file). In both cases you don't want to map the fpm port to your host.
 
 ```console
 $ docker run -d nextcloud:fpm


### PR DESCRIPTION
I managed to fail to read the official documentation in its entirety before finding this fpm dockerfile. Unfortunately, I couldn't guess at how to configure nginx appropriately on my own (although I think I was pretty close..) so I ended up using the apache image. Later I noticed the nginx configuration is described in the official documentation. I might have used the fpm dockerfile had I known that it was already documented! Hopefully this link avoids that situation for anyone else in the future.