### PR TITLE
Revert volumes_from change made in #1644

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    labels:
+      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -63,11 +65,11 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
-    volumes_from:
-      - proxy
     volumes:
-      - certs:/etc/nginx/certs:rw
+      - certs:/etc/nginx/certs
       - acme:/etc/acme.sh
+      - vhost.d:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    labels:
+      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -72,11 +74,11 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
-    volumes_from:
-      - proxy
     volumes:
-      - certs:/etc/nginx/certs:rw
+      - certs:/etc/nginx/certs
       - acme:/etc/acme.sh
+      - vhost.d:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    labels:
+      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -60,11 +62,11 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
-    volumes_from:
-      - proxy
     volumes:
-      - certs:/etc/nginx/certs:rw
+      - certs:/etc/nginx/certs
       - acme:/etc/acme.sh
+      - vhost.d:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    labels:
+      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       - certs:/etc/nginx/certs:ro
       - vhost.d:/etc/nginx/vhost.d
@@ -69,11 +71,11 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
-    volumes_from:
-      - proxy
     volumes:
-      - certs:/etc/nginx/certs:rw
+      - certs:/etc/nginx/certs
       - acme:/etc/acme.sh
+      - vhost.d:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - proxy-tier


### PR DESCRIPTION
I switched in #1644 to the use of volumes_from but only tested it for the docker version 2.
Unfortunately this isn't supported in version 3 anymore.
This PR reverts the change.