### PR TITLE
simplify first character check in entrypoint.sh

### DIFF
--- a/23/fpm-alpine/entrypoint.sh
+++ b/23/fpm-alpine/entrypoint.sh
@@ -57,7 +57,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             file_env REDIS_HOST_PASSWORD
             echo 'session.save_handler = redis'
             # check if redis host is an unix socket path
-            if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
+            if [ "${REDIS_HOST:0:1}" = "/" ]; then
               if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
                 echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
               else


### PR DESCRIPTION
"$(echo "$REDIS_HOST" | cut -c1-1)" equals "${REDIS_HOST:0:1}" , shorter and hopefully faster.