### PR TITLE
Add healthcheck

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -129,5 +129,6 @@ RUN set -ex; \
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/nextcloud/config/
 
+HEALTHCHECK CMD ["curl", "--fail", "http://localhost/status.php"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -147,5 +147,6 @@ RUN set -ex; \
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/nextcloud/config/
 
+HEALTHCHECK CMD ["curl", "--fail", "http://localhost/status.php"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]


### PR DESCRIPTION
This communicates to the built-in serverinfo system to see if the Nextcloud instance is healthy.

I have marked this as WIP because this won't work under php-fpm and I'm not sure how to deal with that. If https://github.com/nextcloud/serverinfo/issues/190 gets implemented this could be made to work in both regular and php-fpm version.

This could also be implemented without `jq` by using sed as follows (` | sed -n 's;<status>\(.*\)</status>;\1;p')`) but this is definitely less clean and may cause unexpected issues if there is ever another "status" field added so I wouldn't recommend that.