### PR TITLE
Increase (double) opcache string buffer size

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -79,7 +79,7 @@ ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_UPLOAD_LIMIT 512M
 RUN { \
         echo 'opcache.enable=1'; \
-        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.interned_strings_buffer=16'; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -93,7 +93,7 @@ RUN set -ex; \
 # see https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 RUN { \
         echo 'opcache.enable=1'; \
-        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.interned_strings_buffer=16'; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \


### PR DESCRIPTION
This fixes https://github.com/nextcloud/docker/issues/1692
Fixes https://github.com/nextcloud/server/issues/31223