### PR TITLE
Using volumes_from instead of volumes for cron in examples

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -35,8 +35,8 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -43,8 +43,8 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -32,8 +32,8 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -40,8 +40,8 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -39,8 +39,8 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -48,8 +48,8 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -36,8 +36,8 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -45,8 +45,8 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db

--- a/stack.yml
+++ b/stack.yml
@@ -29,8 +29,8 @@ services:
   cron:
     image: nextcloud
     restart: always
-    volumes:
-      - nextcloud:/var/www/html
+    volumes_from:
+      - app
     entrypoint: /cron.sh
     depends_on:
       - db


### PR DESCRIPTION
Using volumes_from instead of volumes in the cron container to make sure it had access to all mounts that app container have and that will help new people that will be using docker cron to not have my problem. #1709 

Signed-off-by: Karem Sobhy <karemsobhy020@gmail.com>