### PR TITLE
Add `NEXTCLOUD_INIT_LOCK` to enable shared html volume update

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ The install and update script is only triggered when a default command is used (
 
 - `NEXTCLOUD_UPDATE` (default: `0`)
 
+If you share your html folder with multiple docker containers, you might want to avoid multiple processes updating the same shared volume
+
+- `NEXTCLOUD_INIT_LOCK` (not set by default) Set it to true to enable initialization locking. Other containers will wait for the current process to finish updating the html volume to continue.
+
 If you want to use Redis you have to create a separate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker-compose file. To inform Nextcloud about the Redis container, pass in the following parameters:
 
 - `REDIS_HOST` (not set by default) Name of Redis container

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -103,12 +103,13 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization
+        # it to be done, then escape initalization.
+        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
         lock=/var/www/html/nextcloud-init-sync.lock
         count=0
         limit=10
 
-        if [ -f "$lock" ]; then
+        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
             until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
             do
                 count=$((count+1))


### PR DESCRIPTION
cc @meonkeys

Fix #1742 
Closes #1757 

## Easy reproducibility test

1. Clone this repo
2. Copy the `docker-entrypoint.sh` into `24/apache/entrypoint.sh`
3. Change current directory for `24/apache`
4. Edit the Dockerfile to
    ```Dockerfile
	FROM nextcloud:apache

	COPY *.sh upgrade.exclude /
	  
	ENTRYPOINT ["/entrypoint.sh"]
	CMD ["apache2-foreground"]
    ```
6. Build the image `docker build .` and save the built image hash (here `6e7615a878a6`)
    ![image](https://user-images.githubusercontent.com/14975046/171337632-21e8890a-e5ec-4171-b294-5966226d43bb.png)
7. Create a dummy folder `mkdir /tmp/ncdocker`
8. Open two cosole and run this command at the same time in each shells (replace the hash by yours)
    ```bash
    docker run -e NEXTCLOUD_INIT_LOCK=true -e NEXTCLOUD_ADMIN_USER=admin \
      -e NEXTCLOUD_ADMIN_PASSWORD=admin -e SQLITE_DATABASE=true \
      -v /tmp/ncdocker:/var/www/html 6e7615a878a6
    ```
9. See one of the two processes waiting for the other to complete


| Without `NEXTCLOUD_INIT_LOCK` | With `NEXTCLOUD_INIT_LOCK=true` |
|:---------:|:------:|
|![image](https://user-images.githubusercontent.com/14975046/171338813-e29514c4-f00c-4a0a-8361-4cb29f4d3ed5.png)|![image](https://user-images.githubusercontent.com/14975046/171337273-560e9ebd-a7c3-4e09-9415-0ce1f8675bd6.png)|