### PR TITLE
Add crond log level environment variable

### DIFF
--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -l 0 -L /dev/stdout
+exec busybox crond -f -l ${NEXTCLOUD_CRON_LOG_LEVEL:-0} -L /dev/stdout

--- a/stack.yml
+++ b/stack.yml
@@ -32,6 +32,8 @@ services:
     volumes:
       - nextcloud:/var/www/html
     entrypoint: /cron.sh
+  # environment:
+  #   - NEXTCLOUD_CRON_LOG_LEVEL=8
     depends_on:
       - db
 


### PR DESCRIPTION
I couldn't find any documentation regarding the second cron entry point, I just found it in the stack.yaml.
I added an environment variable to configure the log level, the default case is logging every minute about 3 lines and I found that quite much - not everyone can configure it how he wants it. The default is `0` just as before.

Signed-off-by: Marcel <34819524+MarcelCoding@users.noreply.github.com>