### PR TITLE
Add words to README to draw attention to the use of upgrades.exclude, potential for files to be removed during installation/upgrades.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ $ docker run -d \
 -v theme:/var/www/html/themes/<YOUR_CUSTOM_THEME> \
 nextcloud
 ```
+If mounting additional volumes, you should note that data inside the main folder (`/var/www/html`) may be removed during installation and upgrades, unless listed in [upgrade.exclude](https://github.com/nextcloud/docker/blob/master/upgrade.exclude). You should consider:
+- Confirming that [upgrade.exclude](https://github.com/nextcloud/docker/blob/master/upgrade.exclude) contains the files and folders that should persist during installation and upgrades; or 
+- Mounting storage volumes to locations outside of `/var/www/html`.
+
 
 ## Using the Nextcloud command-line interface
 To use the [Nextcloud command-line interface](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html) (aka. `occ` command):


### PR DESCRIPTION
During installation and upgrades files under the main folder may be removed if not listed in upgrade.exclude. Adding a note to the README, in the section discussing the use of persistent volumes, would help make this behaviour clearer and reduce the risk of accidental data loss.

Examples of situations where this change may provide benefit include:
- #1165
- #1528 
- #1233 

This PR addresses essentially the same issue as PR #1168 (and potentially replaces it). I've opened a new PR as I've proposed a rephrased explanation that I think is clearer about the options, and because the previous PR is outdated.