### PR TITLE
Enable MariaDB binary log

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   db:
     image: mariadb:10.5
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   db:
     image: mariadb:10.5
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   db:
     image: mariadb:10.5
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   db:
     image: mariadb:10.5
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     restart: always
     volumes:
       - db:/var/lib/mysql

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ services:
   db:
     image: mariadb:10.5
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     volumes:
       - db:/var/lib/mysql
     environment:
@@ -287,7 +287,7 @@ services:
   db:
     image: mariadb:10.5
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --expire-logs-days=2 --binlog-format=ROW
     volumes:
       - db:/var/lib/mysql
     environment:


### PR DESCRIPTION
This resolves a warning in the database server log:

    [Warning] You need to use --log-bin to make --binlog-format work.

Pros:

* support for point-in-time recovery
* necessary for replication

Cons:

* slows down database operations ("slightly", per the manual)
* takes up disk space (mitigated by `--expire-logs-days=2`)

See also:

* <https://mariadb.com/kb/en/binary-log/>
* <https://mariadb.com/kb/en/full-list-of-mariadb-options-system-and-status-variables/>

Alternatives:

1. Do not add `--log-bin`. Remove `--binlog-format` instead. This causes the least amount of change for existing installations.

Signed-off-by: Adam Monsen <haircut@gmail.com>