### PR TITLE
Missing cron package in php:8.1-apache-bullseye image. 

### DIFF
--- a/25/apache/Dockerfile
+++ b/25/apache/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        cron \
         rsync \
         bzip2 \
         busybox-static \


### PR DESCRIPTION
Missing cron package in php:8.1-apache-bullseye image. 

Cron job defined below:
```
 mkdir -p /var/spool/cron/crontabs; \
  echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
```
cannot be launched due to the lack of a package.

Background job does not work:
https://docs.nextcloud.com/server/25/admin_manual/configuration_server/background_jobs_configuration.html#cron

Need to add a cron package to nextcloud image. 

Signed-off-by: Łukasz  <54245875+rvva@users.noreply.github.com>