### PR TITLE
Use flock for the upgrade lock

### DIFF
--- a/23/apache/entrypoint.sh
+++ b/23/apache/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/23/apache/entrypoint.sh
+++ b/23/apache/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/23/fpm-alpine/entrypoint.sh
+++ b/23/fpm-alpine/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/23/fpm-alpine/entrypoint.sh
+++ b/23/fpm-alpine/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/23/fpm/entrypoint.sh
+++ b/23/fpm/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/23/fpm/entrypoint.sh
+++ b/23/fpm/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/24/apache/entrypoint.sh
+++ b/24/apache/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/24/apache/entrypoint.sh
+++ b/24/apache/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/24/fpm-alpine/entrypoint.sh
+++ b/24/fpm-alpine/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/24/fpm-alpine/entrypoint.sh
+++ b/24/fpm-alpine/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/24/fpm/entrypoint.sh
+++ b/24/fpm/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/24/fpm/entrypoint.sh
+++ b/24/fpm/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/25/apache/entrypoint.sh
+++ b/25/apache/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/25/apache/entrypoint.sh
+++ b/25/apache/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/25/fpm-alpine/entrypoint.sh
+++ b/25/fpm-alpine/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/25/fpm-alpine/entrypoint.sh
+++ b/25/fpm-alpine/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/25/fpm/entrypoint.sh
+++ b/25/fpm/entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -222,19 +101,132 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
             fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
-        do_install_or_upgrade
-    fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/25/fpm/entrypoint.sh
+++ b/25/fpm/entrypoint.sh
@@ -43,6 +43,127 @@ file_env() {
     unset "$fileVar"
 }
 
+do_install_or_upgrade() {
+    installed_version="0.0.0.0"
+    if [ -f /var/www/html/version.php ]; then
+        # shellcheck disable=SC2016
+        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+    fi
+    # shellcheck disable=SC2016
+    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+    if version_greater "$installed_version" "$image_version"; then
+        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+        exit 1
+    fi
+
+    if version_greater "$image_version" "$installed_version"; then
+        echo "Initializing nextcloud $image_version ..."
+        if [ "$installed_version" != "0.0.0.0" ]; then
+            echo "Upgrading nextcloud from $installed_version ..."
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+        fi
+        if [ "$(id -u)" = 0 ]; then
+            rsync_options="-rlDog --chown $user:$group"
+        else
+            rsync_options="-rlD"
+        fi
+
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            fi
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
+
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
+
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                fi
+
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
+
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
+            fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
+
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
+        fi
+
+        echo "Initializing finished"
+    fi
+
+    # Update htaccess after init if requested
+    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+        run_as 'php /var/www/html/occ maintenance:update:htaccess'
+    fi
+}
+
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -99,152 +220,21 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         } > /usr/local/etc/php/conf.d/redis-session.ini
     fi
 
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+    # If another process is syncing the html folder, wait for
+    # it to be done, then escape initalization.
+    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
+    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
+        (
+            if ! flock -n 9; then
+                # If we couldn't get it immediately, show a message, then wait for real
+                echo "Another process is initializing Nextcloud. Waiting..."
+                flock 9
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
-
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
-                fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
-
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
-
-            fi
-
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
-        fi
+            do_install_or_upgrade
+        ) 9> /var/www/html/nextcloud-init-sync.lock
+    else
+        do_install_or_upgrade
     fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-
 fi
 
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -137,11 +137,7 @@ The install and update script is only triggered when a default command is used (
 
 - `NEXTCLOUD_UPDATE` (default: `0`)
 
-If you share your html folder with multiple docker containers, you might want to avoid multiple processes updating the same shared volume
-
-- `NEXTCLOUD_INIT_LOCK` (not set by default) Set it to true to enable initialization locking. Other containers will wait for the current process to finish updating the html volume to continue.
-
-You might also want to make sure the htaccess is up to date after each container update. Especially on multiple swarm nodes as any discrepancy will make your server unusable.
+You might want to make sure the htaccess is up to date after each container update. Especially on multiple swarm nodes as any discrepancy will make your server unusable.
 
 - `NEXTCLOUD_INIT_HTACCESS` (not set by default) Set it to true to enable run `occ maintenance:update:htaccess` after container initialization.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,120 +69,93 @@ do_install_or_upgrade() {
             rsync_options="-rlD"
         fi
 
-        # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
-        count=0
-        limit=10
-
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
-            do
-                count=$((count+1))
-                wait=$((count*10))
-                echo "Another process is initializing Nextcloud. Waiting $wait seconds..."
-                sleep $wait
-            done
-            if [ "$count" -gt "$limit" ]; then
-                echo "Timeout while waiting for an ongoing initialization"
-                exit 1
+        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        for dir in config data custom_apps themes; do
+            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
             fi
-            echo "The other process is done, assuming complete initialization"
-        else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+        done
+        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
-            for dir in config data custom_apps themes; do
-                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-                fi
-            done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+        # Install
+        if [ "$installed_version" = "0.0.0.0" ]; then
+            echo "New nextcloud instance"
 
-            # Install
-            if [ "$installed_version" = "0.0.0.0" ]; then
-                echo "New nextcloud instance"
+            file_env NEXTCLOUD_ADMIN_PASSWORD
+            file_env NEXTCLOUD_ADMIN_USER
 
-                file_env NEXTCLOUD_ADMIN_PASSWORD
-                file_env NEXTCLOUD_ADMIN_USER
-
-                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                # shellcheck disable=SC2016
+                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                    fi
-
-                    file_env MYSQL_DATABASE
-                    file_env MYSQL_PASSWORD
-                    file_env MYSQL_USER
-                    file_env POSTGRES_DB
-                    file_env POSTGRES_PASSWORD
-                    file_env POSTGRES_USER
-
-                    install=false
-                    if [ -n "${SQLITE_DATABASE+x}" ]; then
-                        echo "Installing with SQLite database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                        install=true
-                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                        echo "Installing with MySQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                        install=true
-                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                        echo "Installing with PostgreSQL database"
-                        # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                        install=true
-                    fi
-
-                    if [ "$install" = true ]; then
-                        echo "Starting nextcloud installation"
-                        max_retries=10
-                        try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                        do
-                            echo "Retrying install..."
-                            try=$((try+1))
-                            sleep 10s
-                        done
-                        if [ "$try" -gt "$max_retries" ]; then
-                            echo "Installing of nextcloud failed!"
-                            exit 1
-                        fi
-                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                            echo "Setting trusted domains…"
-                            NC_TRUSTED_DOMAIN_IDX=1
-                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                            done
-                        fi
-                    else
-                        echo "Please run the web-based installer on first connect!"
-                    fi
+                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
                 fi
-            # Upgrade
-            else
-                run_as 'php /var/www/html/occ upgrade'
 
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-                rm -f /tmp/list_before /tmp/list_after
+                file_env MYSQL_DATABASE
+                file_env MYSQL_PASSWORD
+                file_env MYSQL_USER
+                file_env POSTGRES_DB
+                file_env POSTGRES_PASSWORD
+                file_env POSTGRES_USER
 
+                install=false
+                if [ -n "${SQLITE_DATABASE+x}" ]; then
+                    echo "Installing with SQLite database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                    install=true
+                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                    echo "Installing with MySQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                    install=true
+                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                    echo "Installing with PostgreSQL database"
+                    # shellcheck disable=SC2016
+                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                    install=true
+                fi
+
+                if [ "$install" = true ]; then
+                    echo "Starting nextcloud installation"
+                    max_retries=10
+                    try=0
+                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                    do
+                        echo "Retrying install..."
+                        try=$((try+1))
+                        sleep 10s
+                    done
+                    if [ "$try" -gt "$max_retries" ]; then
+                        echo "Installing of nextcloud failed!"
+                        exit 1
+                    fi
+                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                        echo "Setting trusted domains…"
+                        NC_TRUSTED_DOMAIN_IDX=1
+                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                        done
+                    fi
+                else
+                    echo "Please run the web-based installer on first connect!"
+                fi
             fi
+        # Upgrade
+        else
+            run_as 'php /var/www/html/occ upgrade'
 
-            # Initialization done, reset lock
-            rm $lock
-            echo "Initializing finished"
+            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+            echo "The following apps have been disabled:"
+            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+            rm -f /tmp/list_before /tmp/list_after
+
         fi
+
+        echo "Initializing finished"
     fi
 
     # Update htaccess after init if requested

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -222,19 +222,14 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
     # If another process is syncing the html folder, wait for
     # it to be done, then escape initalization.
-    # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-    if [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-        (
-            if ! flock -n 9; then
-                # If we couldn't get it immediately, show a message, then wait for real
-                echo "Another process is initializing Nextcloud. Waiting..."
-                flock 9
-            fi
-            do_install_or_upgrade
-        ) 9> /var/www/html/nextcloud-init-sync.lock
-    else
+    (
+        if ! flock -n 9; then
+            # If we couldn't get it immediately, show a message, then wait for real
+            echo "Another process is initializing Nextcloud. Waiting..."
+            flock 9
+        fi
         do_install_or_upgrade
-    fi
+    ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,127 +43,6 @@ file_env() {
     unset "$fileVar"
 }
 
-do_install_or_upgrade() {
-    installed_version="0.0.0.0"
-    if [ -f /var/www/html/version.php ]; then
-        # shellcheck disable=SC2016
-        installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
-    fi
-    # shellcheck disable=SC2016
-    image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
-
-    if version_greater "$installed_version" "$image_version"; then
-        echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
-        exit 1
-    fi
-
-    if version_greater "$image_version" "$installed_version"; then
-        echo "Initializing nextcloud $image_version ..."
-        if [ "$installed_version" != "0.0.0.0" ]; then
-            echo "Upgrading nextcloud from $installed_version ..."
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
-        fi
-        if [ "$(id -u)" = 0 ]; then
-            rsync_options="-rlDog --chown $user:$group"
-        else
-            rsync_options="-rlD"
-        fi
-
-        rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
-        for dir in config data custom_apps themes; do
-            if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
-                rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-            fi
-        done
-        rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
-
-        # Install
-        if [ "$installed_version" = "0.0.0.0" ]; then
-            echo "New nextcloud instance"
-
-            file_env NEXTCLOUD_ADMIN_PASSWORD
-            file_env NEXTCLOUD_ADMIN_USER
-
-            if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
-                # shellcheck disable=SC2016
-                install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
-                if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
-                fi
-
-                file_env MYSQL_DATABASE
-                file_env MYSQL_PASSWORD
-                file_env MYSQL_USER
-                file_env POSTGRES_DB
-                file_env POSTGRES_PASSWORD
-                file_env POSTGRES_USER
-
-                install=false
-                if [ -n "${SQLITE_DATABASE+x}" ]; then
-                    echo "Installing with SQLite database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database-name "$SQLITE_DATABASE"'
-                    install=true
-                elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
-                    echo "Installing with MySQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
-                    install=true
-                elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
-                    echo "Installing with PostgreSQL database"
-                    # shellcheck disable=SC2016
-                    install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
-                    install=true
-                fi
-
-                if [ "$install" = true ]; then
-                    echo "Starting nextcloud installation"
-                    max_retries=10
-                    try=0
-                    until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
-                    do
-                        echo "Retrying install..."
-                        try=$((try+1))
-                        sleep 10s
-                    done
-                    if [ "$try" -gt "$max_retries" ]; then
-                        echo "Installing of nextcloud failed!"
-                        exit 1
-                    fi
-                    if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
-                        echo "Setting trusted domains…"
-                        NC_TRUSTED_DOMAIN_IDX=1
-                        for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
-                            DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                            run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
-                            NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
-                        done
-                    fi
-                else
-                    echo "Please run the web-based installer on first connect!"
-                fi
-            fi
-        # Upgrade
-        else
-            run_as 'php /var/www/html/occ upgrade'
-
-            run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-            echo "The following apps have been disabled:"
-            diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
-            rm -f /tmp/list_before /tmp/list_after
-
-        fi
-
-        echo "Initializing finished"
-    fi
-
-    # Update htaccess after init if requested
-    if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
-        run_as 'php /var/www/html/occ maintenance:update:htaccess'
-    fi
-}
-
 if expr "$1" : "apache" 1>/dev/null; then
     if [ -n "${APACHE_DISABLE_REWRITE_IP+x}" ]; then
         a2disconf remoteip
@@ -228,7 +107,125 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             echo "Another process is initializing Nextcloud. Waiting..."
             flock 9
         fi
-        do_install_or_upgrade
+
+        installed_version="0.0.0.0"
+        if [ -f /var/www/html/version.php ]; then
+            # shellcheck disable=SC2016
+            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+        fi
+        # shellcheck disable=SC2016
+        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+
+        if version_greater "$installed_version" "$image_version"; then
+            echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
+            exit 1
+        fi
+
+        if version_greater "$image_version" "$installed_version"; then
+            echo "Initializing nextcloud $image_version ..."
+            if [ "$installed_version" != "0.0.0.0" ]; then
+                echo "Upgrading nextcloud from $installed_version ..."
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+            fi
+            if [ "$(id -u)" = 0 ]; then
+                rsync_options="-rlDog --chown $user:$group"
+            else
+                rsync_options="-rlD"
+            fi
+
+            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            for dir in config data custom_apps themes; do
+                if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
+                    rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                fi
+            done
+            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+
+            # Install
+            if [ "$installed_version" = "0.0.0.0" ]; then
+                echo "New nextcloud instance"
+
+                file_env NEXTCLOUD_ADMIN_PASSWORD
+                file_env NEXTCLOUD_ADMIN_USER
+
+                if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
+                    # shellcheck disable=SC2016
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
+                    fi
+
+                    file_env MYSQL_DATABASE
+                    file_env MYSQL_PASSWORD
+                    file_env MYSQL_USER
+                    file_env POSTGRES_DB
+                    file_env POSTGRES_PASSWORD
+                    file_env POSTGRES_USER
+
+                    install=false
+                    if [ -n "${SQLITE_DATABASE+x}" ]; then
+                        echo "Installing with SQLite database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database-name "$SQLITE_DATABASE"'
+                        install=true
+                    elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
+                        echo "Installing with MySQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install=true
+                    elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
+                        echo "Installing with PostgreSQL database"
+                        # shellcheck disable=SC2016
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install=true
+                    fi
+
+                    if [ "$install" = true ]; then
+                        echo "Starting nextcloud installation"
+                        max_retries=10
+                        try=0
+                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        do
+                            echo "Retrying install..."
+                            try=$((try+1))
+                            sleep 10s
+                        done
+                        if [ "$try" -gt "$max_retries" ]; then
+                            echo "Installing of nextcloud failed!"
+                            exit 1
+                        fi
+                        if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+                            echo "Setting trusted domains…"
+                            NC_TRUSTED_DOMAIN_IDX=1
+                            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+                                DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                                run_as "php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN"
+                                NC_TRUSTED_DOMAIN_IDX=$((NC_TRUSTED_DOMAIN_IDX+1))
+                            done
+                        fi
+                    else
+                        echo "Please run the web-based installer on first connect!"
+                    fi
+                fi
+            # Upgrade
+            else
+                run_as 'php /var/www/html/occ upgrade'
+
+                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
+                echo "The following apps have been disabled:"
+                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                rm -f /tmp/list_before /tmp/list_after
+
+            fi
+
+            echo "Initializing finished"
+        fi
+
+        # Update htaccess after init if requested
+        if [ -n "${NEXTCLOUD_INIT_HTACCESS+x}" ] && [ "$installed_version" != "0.0.0.0" ]; then
+            run_as 'php /var/www/html/occ maintenance:update:htaccess'
+        fi
     ) 9> /var/www/html/nextcloud-init-sync.lock
 fi
 


### PR DESCRIPTION
Fixes #1903

This keeps the `NEXTCLOUD_INIT_LOCK` environment variable, though I don't know if it is still required. Without it, I don't need to factor `do_install_or_upgrade()` (because it's not called twice).

Locking around the entire upgrade process allows the container to check the version at the right time (so it can tell whether the upgrade is needed, e.g. it might have failed).

I think there is still a problem that the file copy might have completed but `occ upgrade` might not have finished, but I'm not sure how to detect that. The simplest way is to just always run `occ upgrade`, which succeeds immediately if there's nothing to do.