### PR TITLE
try 2: use flock automatic lock for upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ The install and update script is only triggered when a default command is used (
 
 If you share your html folder with multiple docker containers, you might want to avoid multiple processes updating the same shared volume
 
-- `NEXTCLOUD_INIT_LOCK` (not set by default) Set it to true to enable initialization locking. Other containers will wait for the current process to finish updating the html volume to continue.
-
-You might also want to make sure the htaccess is up to date after each container update. Especially on multiple swarm nodes as any discrepancy will make your server unusable.
-
 - `NEXTCLOUD_INIT_HTACCESS` (not set by default) Set it to true to enable run `occ maintenance:update:htaccess` after container initialization.
 
 If you want to use Redis you have to create a separate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker-compose file. To inform Nextcloud about the Redis container, pass in the following parameters:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -234,7 +234,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
             echo "Initializing finished"
         fi
-        ) 9> /var/lock/nextcloud-init-sync.lock
+        ) 9> /var/www/html/nextcloud-init-sync.lock
     fi
 
     # Update htaccess after init if requested

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -126,7 +126,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
         # Prevent multiple images syncing simultaneously:
         # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization
+        # it to be done, then escape initalization.
         count=0
         limit=10
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -124,15 +124,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             rsync_options="-rlD"
         fi
 
+        # Prevent multiple images syncing simultaneously:
         # If another process is syncing the html folder, wait for
-        # it to be done, then escape initalization.
-        # You need to define the NEXTCLOUD_INIT_LOCK environment variable
-        lock=/var/www/html/nextcloud-init-sync.lock
+        # it to be done, then escape initalization
         count=0
         limit=10
 
-        if [ -f "$lock" ] && [ -n "${NEXTCLOUD_INIT_LOCK+x}" ]; then
-            until [ ! -f "$lock" ] || [ "$count" -gt "$limit" ]
+        (
+        if ! flock -n 9; then
+            until flock -n 9 || [ "$count" -gt "$limit" ]
             do
                 count=$((count+1))
                 wait=$((count*10))
@@ -145,8 +145,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             fi
             echo "The other process is done, assuming complete initialization"
         else
-            # Prevent multiple images syncing simultaneously
-            touch $lock
             rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
 
             for dir in config data custom_apps themes; do
@@ -234,10 +232,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
             fi
 
-            # Initialization done, reset lock
-            rm $lock
             echo "Initializing finished"
         fi
+        ) 9> /var/lock/nextcloud-init-sync.lock
     fi
 
     # Update htaccess after init if requested


### PR DESCRIPTION
This is #1757, revisited.

Only this *or* #1905 should be merged (if either are merged). Both PRs intend a change from (a) treating `nextcloud-init-sync.lock`'s existence to indicate an upgrade in progress to (b) using the `flock` shell command (either GNU's or Busybox's). Switching to (b) provides an atomic and ephemeral (automatically cleaned-up) lock.