### PR TITLE
set display_errors to Off

### DIFF
--- a/23/apache/Dockerfile
+++ b/23/apache/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/23/fpm-alpine/Dockerfile
+++ b/23/fpm-alpine/Dockerfile
@@ -96,6 +96,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/23/fpm/Dockerfile
+++ b/23/fpm/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/24/apache/Dockerfile
+++ b/24/apache/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/24/fpm-alpine/Dockerfile
+++ b/24/fpm-alpine/Dockerfile
@@ -96,6 +96,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/24/fpm/Dockerfile
+++ b/24/fpm/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/25/apache/Dockerfile
+++ b/25/apache/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/25/fpm-alpine/Dockerfile
+++ b/25/fpm-alpine/Dockerfile
@@ -96,6 +96,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/25/fpm/Dockerfile
+++ b/25/fpm/Dockerfile
@@ -108,6 +108,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \\n
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -95,6 +95,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -109,6 +109,7 @@ RUN { \
         echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo 'display_errors=Off'; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \


### PR DESCRIPTION
This PR provents errors to be put in the HTTP response.

The errors should not be displayed on production systems. E.g. the [PHP docs](https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors) says: "This is a feature to support your development and should never be used on production systems (e.g. systems connected to the internet)."

Besides of security implications, having the errors displayed makes it impossible to catch some problems e.g. exceeding max_post_size.
