### PR TITLE
Refactor env vars from file

### DIFF
--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -1,37 +1,25 @@
 <?php
 
+require_once "util.php";
+
 $autoconfig_enabled = false;
 
 if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbtype'] = 'sqlite';
     $AUTOCONFIG['dbname'] = getenv('SQLITE_DATABASE');
     $autoconfig_enabled = true;
-} elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
+} elseif (getFileEnv('MYSQL_DATABASE') && getFileEnv('MYSQL_USER') && getFileEnv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
     $AUTOCONFIG['dbtype'] = 'mysql';
-    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
-    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
-    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
+    $AUTOCONFIG['dbname'] = getFileEnv('MYSQL_DATABASE');
+    $AUTOCONFIG['dbuser'] = getFileEnv('MYSQL_USER');
+    $AUTOCONFIG['dbpass'] = getFileEnv('MYSQL_PASSWORD');
     $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
     $autoconfig_enabled = true;
-} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'mysql';
-    $AUTOCONFIG['dbname'] = getenv('MYSQL_DATABASE');
-    $AUTOCONFIG['dbuser'] = getenv('MYSQL_USER');
-    $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
-    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
-    $autoconfig_enabled = true;
-} elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
+} elseif (getFileEnv('POSTGRES_DB') && getFileEnv('POSTGRES_USER') && getFileEnv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG['dbtype'] = 'pgsql';
-    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
-    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
-    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
-    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
-    $autoconfig_enabled = true;
-} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'pgsql';
-    $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
-    $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
-    $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
+    $AUTOCONFIG['dbname'] = getFileEnv('POSTGRES_DB');
+    $AUTOCONFIG['dbuser'] = getFileEnv('POSTGRES_USER');
+    $AUTOCONFIG['dbpass'] = getFileEnv('POSTGRES_PASSWORD');
     $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
     $autoconfig_enabled = true;
 }

--- a/.config/smtp.config.php
+++ b/.config/smtp.config.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once "util.php";
+
 if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
   $CONFIG = array (
     'mail_smtpmode' => 'smtp',
@@ -8,15 +11,8 @@ if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN'))
     'mail_smtpauth' => getenv('SMTP_NAME') && (getenv('SMTP_PASSWORD') || (getenv('SMTP_PASSWORD_FILE') && file_exists(getenv('SMTP_PASSWORD_FILE')))),
     'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
     'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+    'mail_smtppassword' => getFileEnv('SMTP_PASSWORD', ''),
     'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
     'mail_domain' => getenv('MAIL_DOMAIN'),
   );
-
-  if (getenv('SMTP_PASSWORD_FILE') && file_exists(getenv('SMTP_PASSWORD_FILE'))) {
-      $CONFIG['mail_smtppassword'] = trim(file_get_contents(getenv('SMTP_PASSWORD_FILE')));
-  } elseif (getenv('SMTP_PASSWORD')) {
-      $CONFIG['mail_smtppassword'] = getenv('SMTP_PASSWORD');
-  } else {
-      $CONFIG['mail_smtppassword'] = '';
-  }
 }

--- a/.config/util.php
+++ b/.config/util.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gets the value of an environment variable or the contents of the file
+ * at the path specified by its value if it exists with a suffix of "_FILE"
+ */
+function getFileEnv(string $envVarName, ?string $defaultValue): ?string {
+    $FILE_ENV_VAR_SUFFIX = "_FILE";
+
+    $fileEnvVarName = "$envVarName$FILE_ENV_VAR_SUFFIX";
+    $filename = getenv($fileEnvVarName);
+    $envVarValue = getenv($envVarName);
+
+    $configValue = null;
+    if ($filename && file_exists($filename)) {
+        $configValue = trim(file_get_contents($filename));
+    } else if ($envVarValue) {
+        $configValue = $envVarValue;
+    } else if ($defaultValue) {
+        $configValue = $defaultValue;
+    }
+    return $configValue;
+}
+
+?>

--- a/README.md
+++ b/README.md
@@ -388,8 +388,6 @@ secrets:
 
 Currently, this is only supported for `NEXTCLOUD_ADMIN_PASSWORD`, `NEXTCLOUD_ADMIN_USER`, `MYSQL_DATABASE`, `MYSQL_PASSWORD`, `MYSQL_USER`, `POSTGRES_DB`, `POSTGRES_PASSWORD`, `POSTGRES_USER`, `REDIS_HOST_PASSWORD`, `SMTP_PASSWORD`, `OBJECTSTORE_S3_KEY`, and `OBJECTSTORE_S3_SECRET`.
 
-If you set any group of values (i.e. all of `MYSQL_DATABASE_FILE`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`, `MYSQL_HOST`), the script will not use the corresponding group of environment variables (`MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`).
-
 # Make your Nextcloud available from the internet
 Until here, your Nextcloud is just available from your docker host. If you want your Nextcloud available from the internet adding SSL encryption is mandatory.
 


### PR DESCRIPTION
This PR depends on all 'environment variable from file' changes. What is included in it vs. what is included in other open pull requests depends on the order in which they are merged. I suggest merging the feature branches first, and then making changes to this refactor pull request as needed. I would be happy to bring this up-to-date after the other PRs are merged.

Note that as a result of this pull request, the database configuration environment variables will become independent. That is, for example, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` may be defined to be from file or not independently. No longer will there be confusion over defining some but not all from file.

- [x] documentation
- [ ] testing

Related to #1938, #1945

Closes #1940