### PR TITLE
Reference latest instead of hardcoded version in admin manual links

### DIFF
--- a/.examples/README.md
+++ b/.examples/README.md
@@ -22,13 +22,13 @@ Example | Description
 NOTE: [this container must run as root or `cron.php` will not run](https://github.com/nextcloud/docker/issues/1899).
 
 ### full
-The `full` Dockerfile example adds dependencies for all optional packages suggested by nextcloud that may be needed for some features (e.g. Video Preview Generation), as stated in the [Administration Manual](https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html).
+The `full` Dockerfile example adds dependencies for all optional packages suggested by nextcloud that may be needed for some features (e.g. Video Preview Generation), as stated in the [Administration Manual](https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html).
 
 NOTE: The Dockerfile does not install the LibreOffice package (line is commented), because it would increase the generated Image size by approximately 500 MB. In order to install it, simply uncomment the appropriate line in the Dockerfile.
 
-NOTE: Per default, only previews for BMP, GIF, JPEG, MarkDown, MP3, PNG, TXT, and XBitmap Files are generated. The configuration of the preview generation can be done in config.php, as explained in the [Administration Manual](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/config_sample_php_parameters.html#previews)
+NOTE: Per default, only previews for BMP, GIF, JPEG, MarkDown, MP3, PNG, TXT, and XBitmap Files are generated. The configuration of the preview generation can be done in config.php, as explained in the [Administration Manual](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#previews)
 
-NOTE: Nextcloud recommends [disabling preview generation](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/harden_server.html?highlight=enabledpreviewproviders#disable-preview-image-generation) for high security deployments, as preview generation opens your nextcloud instance to new possible attack vectors.
+NOTE: Nextcloud recommends [disabling preview generation](https://docs.nextcloud.com/server/latest/admin_manual/installation/harden_server.html#disable-preview-image-generation) for high security deployments, as preview generation opens your nextcloud instance to new possible attack vectors.
 
 The required steps for each optional/recommended package that is not already in the Nextcloud image are listed here, so that the Dockerfile can easily be modified to only install the needed extra packages. Simply remove the steps for the unwanted packages from the Dockerfile.
 


### PR DESCRIPTION
I've intentionally not just replaced the hardcoded version with the current latest one (25) but with the "latest" keyword as the README in the projects root also follows this pattern.