### PR TITLE
Updates X-Robot-Tag in nginx.conf examples

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -61,13 +61,13 @@ http {
         #pagespeed off;
 
         # HTTP response headers borrowed from Nextcloud `.htaccess`
-        add_header Referrer-Policy                      "no-referrer"   always;
-        add_header X-Content-Type-Options               "nosniff"       always;
-        add_header X-Download-Options                   "noopen"        always;
-        add_header X-Frame-Options                      "SAMEORIGIN"    always;
-        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
-        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header Referrer-Policy                      "no-referrer"       always;
+        add_header X-Content-Type-Options               "nosniff"           always;
+        add_header X-Download-Options                   "noopen"            always;
+        add_header X-Frame-Options                      "SAMEORIGIN"        always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+        add_header X-Robots-Tag                         "noindex,nofollow"  always;
+        add_header X-XSS-Protection                     "1; mode=block"     always;
 
         # Remove X-Powered-By, which is an information leak
         fastcgi_hide_header X-Powered-By;

--- a/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
@@ -61,13 +61,13 @@ http {
         #pagespeed off;
 
         # HTTP response headers borrowed from Nextcloud `.htaccess`
-        add_header Referrer-Policy                      "no-referrer"   always;
-        add_header X-Content-Type-Options               "nosniff"       always;
-        add_header X-Download-Options                   "noopen"        always;
-        add_header X-Frame-Options                      "SAMEORIGIN"    always;
-        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
-        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header Referrer-Policy                      "no-referrer"       always;
+        add_header X-Content-Type-Options               "nosniff"           always;
+        add_header X-Download-Options                   "noopen"            always;
+        add_header X-Frame-Options                      "SAMEORIGIN"        always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+        add_header X-Robots-Tag                         "noindex,nofollow"  always;
+        add_header X-XSS-Protection                     "1; mode=block"     always;
 
         # Remove X-Powered-By, which is an information leak
         fastcgi_hide_header X-Powered-By;

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -61,13 +61,13 @@ http {
         #pagespeed off;
 
         # HTTP response headers borrowed from Nextcloud `.htaccess`
-        add_header Referrer-Policy                      "no-referrer"   always;
-        add_header X-Content-Type-Options               "nosniff"       always;
-        add_header X-Download-Options                   "noopen"        always;
-        add_header X-Frame-Options                      "SAMEORIGIN"    always;
-        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
-        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header Referrer-Policy                      "no-referrer"       always;
+        add_header X-Content-Type-Options               "nosniff"           always;
+        add_header X-Download-Options                   "noopen"            always;
+        add_header X-Frame-Options                      "SAMEORIGIN"        always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+        add_header X-Robots-Tag                         "noindex,nofollow"  always;
+        add_header X-XSS-Protection                     "1; mode=block"     always;
 
         # Remove X-Powered-By, which is an information leak
         fastcgi_hide_header X-Powered-By;

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -61,13 +61,13 @@ http {
         #pagespeed off;
 
         # HTTP response headers borrowed from Nextcloud `.htaccess`
-        add_header Referrer-Policy                      "no-referrer"   always;
-        add_header X-Content-Type-Options               "nosniff"       always;
-        add_header X-Download-Options                   "noopen"        always;
-        add_header X-Frame-Options                      "SAMEORIGIN"    always;
-        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
-        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header Referrer-Policy                      "no-referrer"       always;
+        add_header X-Content-Type-Options               "nosniff"           always;
+        add_header X-Download-Options                   "noopen"            always;
+        add_header X-Frame-Options                      "SAMEORIGIN"        always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+        add_header X-Robots-Tag                         "noindex,nofollow"  always;
+        add_header X-XSS-Protection                     "1; mode=block"     always;
 
         # Remove X-Powered-By, which is an information leak
         fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
Nextcloud 26 shows a warning if X-Robot Tag is not set to `noindex, nofollow`