### PR TITLE
Guarantee REDIS_HOST_PORT is never null for UNIX sockets

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -13,5 +13,7 @@ if (getenv('REDIS_HOST')) {
     $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
   } elseif (getenv('REDIS_HOST')[0] != '/') {
     $CONFIG['redis']['port'] = 6379;
+  } elseif (getenv('REDIS_HOST')[0] == '/') {
+    $CONFIG['redis']['port'] = 0;
   }
 }


### PR DESCRIPTION
Addresses #1785 (which arises when using UNIX sockets)

Without this fix, UNIX socket connections won't work if REDIS_HOST is used to specify the socket to the container unless an additional bogus REDIS_HOST_PORT is also specified.

This change makes the auto-generated REDIS socket configuration in the Docker container (which overrides whatever is specified in config.php whenver REDIS_HOST is used) match NC's recommended default (which includes specifying port 0 for sockets). More importantly it's more user friendly and eliminates non-working setups with error messages such as the following (which results in an Internal Server Error):

```
Deprecated: Redis::pconnect(): Passing null to parameter #2 ($port) of type int is deprecated in /var/www/html/lib/private/RedisFactory.php on line 137
```

P.S. I believe this is the only file in the docker repository that needs to be updated manually - my reading is that update.sh is used as part of the release process and will update the ones for each version/config model appropriately. If I'm incorrect let me know and I'll update those too. Should all be the same.