### PR TITLE
(Cron) Preview Generator support

### DIFF
--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -eu
 
+# Set-up cron entry for previewgenerator (https://apps.nextcloud.com/apps/previewgenerator)
+# Note: the user should make sure they install the app first and we could check here but it's non-fatal...
+if [ -n "${CRON_PREVIEW+x}" ]; then
+    echo "Configuring Preview Generator to run at ${CRON_PREVIEW}:00 (24H system time) if /cron.sh is activated"
+    echo "* ${CRON_PREVIEW} * * * /var/www/html/occ preview:pre-generate" >> /var/spool/cron/crontabs/www-data
+fi
+
 exec busybox crond -f -l 0 -L /dev/stdout


### PR DESCRIPTION
Allow the user to enable and configure a cron entry for the NC Preview Generator.

To do so, add `CRON_PREVIEW={hour}` (allowed values for hour are 0-23 since crond uses 24H system) in the startup environment parameters for the cron service container. 

For example, if your Docker environment uses UTC time the following will run the Preview Generator daily at 2:00 AM Eastern Time (also known as 6:00 AM UTC):

```
  cron:
    depends_on:
      - db
      - redis
      - app
    image: nextcloud:24-apache
    restart: unless-stopped
    environment:
      - CRON_PREVIEW=6
    volumes:
      - app-var-www-html:/var/www/html
    entrypoint: /cron.sh
    networks:
      - app-network
```

User must install the Preview Generator app ahead of time from the app store.