### PR TITLE
Compose: Rewrite to HTPS with proxy

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       - MYSQL_HOST=db
       - REDIS_HOST=redis
+      - OVERWRITEPROTOCOL=https
     env_file:
       - db.env
     depends_on:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - POSTGRES_HOST=db
       - REDIS_HOST=redis
+      - OVERWRITEPROTOCOL=https
     env_file:
       - db.env
     depends_on:


### PR DESCRIPTION
For security reasons the OVERWRITEPROTOCOL=https should be set if using a proxy in the 2 examples.
This also shows up in: 
* Security & setup warnings  `settings/admin/overview`
* the desktop client when setting up the connection, it doesn't even let you continue for security reasons.