### PR TITLE
Replace RemoteIPTrustedProxy by RemoteIPInternalProxy in remoteip.conf

### DIFF
--- a/25/apache/Dockerfile
+++ b/25/apache/Dockerfile
@@ -119,9 +119,9 @@ VOLUME /var/www/html
 RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+     echo RemoteIPInternalProxy 10.0.0.0/8 ;\
+     echo RemoteIPInternalProxy 172.16.0.0/12 ;\
+     echo RemoteIPInternalProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
 

--- a/26/apache/Dockerfile
+++ b/26/apache/Dockerfile
@@ -120,9 +120,9 @@ VOLUME /var/www/html
 RUN a2enmod headers rewrite remoteip ;\
     {\
      echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+     echo RemoteIPInternalProxy 10.0.0.0/8 ;\
+     echo RemoteIPInternalProxy 172.16.0.0/12 ;\
+     echo RemoteIPInternalProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
 

--- a/update.sh
+++ b/update.sh
@@ -28,7 +28,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPInternalProxy 10.0.0.0/8 ;\\\n     echo RemoteIPInternalProxy 172.16.0.0/12 ;\\\n     echo RemoteIPInternalProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
 	[fpm]=''
 	[fpm-alpine]=''
 )


### PR DESCRIPTION
Else the internal IP ranges are ignored
See https://httpd.apache.org/docs/2.4/en/mod/mod_remoteip.html#remoteiptrustedproxy and https://httpd.apache.org/docs/2.4/en/mod/mod_remoteip.html#remoteipinternalproxy

It's a problem at least when you have several chained local reverse-proxies. In my case: a frontal reverse-proxy, followed by Traefik (Ingress implementation of k3s) before reaching this docker image.

Symptom: the docker image logs (on stdout) the IP of a reverse-proxy instead of the actual client IP.

Should fix #1103

See also https://help.nextcloud.com/t/apache-docker-behind-reverse-proxy/151754 and https://github.com/nextcloud/helm/issues/164 that mention the same problem, and same fix.

NB: I've submitted a similar PR for wordpress: https://github.com/docker-library/wordpress/pull/830
NB2: in my case, I still have to override remoteip.conf with `RemoteIPHeader X-Forwarded-For` instead of `RemoteIPHeader X-Real-IP`, because `X-Forwarded-For` is the HTTP header my reverse-proxies are using. Even if `X-Forwarded-For` seems a more common use-case to me (it's the one used by wordpress, too), I did not dare to change it in this PR (to not break any backward compatibility). But I can surely do if you ask