### PR TITLE
Enable the custom entrypoint script support added in #1964 to be run as root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ To use the hooks triggered by the `entrypoint` script, either
 - Added your script(s) to the individual of the hook folder(s), which are located at the path `/docker-entrypoint-hooks.d` in the container
 - Use volume(s) if you want to use script from the host system inside the container, see example.
 
-**Note:** Only the script(s) located in a hook folder (not sub-folders), ending with `.sh` and marked as executable, will be executed.
+**Note:** Only the script(s) located in a hook folder (not sub-folders), ending with `.sh` will be executed.
 
 **Example:** Mount using volumes
 ```yaml


### PR DESCRIPTION
In #1964, the scripts were executed as $user by run_as, but for example, new packages could not be added with apt because they lacked root privileges. 

Therefore, I have made changes to ensure that the custom scripts are executed with root privileges. 

Also, as pointed out in the comments at [#r1191243057](https://github.com/nextcloud/docker/pull/1964/files#r1191243057), I have made sure that the custom scripts are executed with `/bin/bash`, even when they do not have execution permissions. 

For example, when using a custom script in a k8s configmap, it is not possible to assign execution permissions, and chmod cannot be used because it is mounted as ReadOnly. There are cases where it is difficult to assign execution permissions, even when you want to add a custom script. 

Ideally, I wanted to do `. script`(sourcing) like in [docker-library/postgres#452](https://github.com/docker-library/postgres/pull/452), but since `entrypoint.sh` is executed with `/bin/sh`, I decided to launch a new `/bin/bash` shell and execute it for the sake of extensibility. 

Additionally, for cases where you want to execute as the nextcloud user, I've made it so that you can reference:
```bash
user=$user /bin/bash "${script_file_path}"
```

inside the custom script with:
```bash
run_as() {
  su -p $user -s /bin/sh -c "$1"
}
```

My apologies for any awkward English as I am not a native speaker.

Best Regards.