### PR TITLE
Apache `LimitRequestBody 0`

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip\\\n    { echo LimitRequestBody 0 ; } > /etc/apache2/conf-available/limitrequestbody.conf;\\\n    a2enconf limitrequestbody'	
+	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip;\\\n    { echo LimitRequestBody 0 ; } > /etc/apache2/conf-available/limitrequestbody.conf;\\\n    a2enconf limitrequestbody'	
  	[fpm]=''
 	[fpm-alpine]=''
 )

--- a/update.sh
+++ b/update.sh
@@ -29,8 +29,8 @@ declare -A base=(
 )
 
 declare -A extras=(
-	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
-	[fpm]=''
+	[apache]='\nRUN a2enmod headers rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip\\\n    { echo LimitRequestBody 0 ; } > /etc/apache2/conf-available/limitrequestbody.conf;\\\n    a2enconf limitrequestbody'	
+ 	[fpm]=''
 	[fpm-alpine]=''
 )
 


### PR DESCRIPTION
Removes the 1GB upload restriction, allowing the PHP setting to work again.

Thanks to @t-schuster for the patch suggestion

Fixes #1796