### PR TITLE
fix erroneous env variable name

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/mysql:Z
     environment:
-      - MYSQL_ROOT_PASSWORD=
+      - MARIADB_ROOT_PASSWORD=
       - MARIADB_AUTO_UPGRADE=1
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/mysql:Z
     environment:
-      - MYSQL_ROOT_PASSWORD=
+      - MARIADB_ROOT_PASSWORD=
       - MARIADB_AUTO_UPGRADE=1
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/mysql:Z
     environment:
-      - MYSQL_ROOT_PASSWORD=
+      - MARIADB_ROOT_PASSWORD=
       - MARIADB_AUTO_UPGRADE=1
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/mysql:Z
     environment:
-      - MYSQL_ROOT_PASSWORD=
+      - MARIADB_ROOT_PASSWORD=
       - MARIADB_AUTO_UPGRADE=1
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:


### PR DESCRIPTION
Fixes #2072 

Short rundown: The env variable `MYSQL_ROOT_PASSWORD` does not work with MariaDB and has to be changed to `MARIADB_ROOT_PASSWORD`

I only tested this with the `docker-compose/insecure/mariadb/apache` compose file but as they all rely on the same images, it should not make a difference and work on all now.

