### PR TITLE
Issue template: Reminder to include  Compose/run + config

### DIFF
--- a/.github/ISSUE_TEMPLATE/Image_issue.md
+++ b/.github/ISSUE_TEMPLATE/Image_issue.md
@@ -6,7 +6,9 @@ about: Issues related to the Nextcloud Docker image
 <!--
 Thanks for reporting issues back to Nextcloud!
 
-Note: This is the issue tracker of the official Nextcloud **Docker image**, please do NOT use this to report issues with Docker or Nextcloud itself. You can find help debugging your system on our forums: https://help.nextcloud.com/ or https://forums.docker.com/.
+When reporting problems, please include your *complete* Docker Compose file (or run commands) and your Nextcloud Server config (e.g. `occ config:list system`). Incomplete reports cause extra work for all parties involved and delay resolution.
+
+Note: This is the issue tracker of the official Nextcloud **Docker image**, please do NOT use this to report issues with Docker or Nextcloud Server itself. You can find help debugging your system on our forums: https://help.nextcloud.com/ or https://forums.docker.com/.
 
 To learn more about official images, see https://github.com/docker-library/faq
 -->


### PR DESCRIPTION
Bug reports often come in lacking Compose files or run commands. Same goes for `config.php`. This just adds a simple reminder to the template.

Ultimately we may want to switch to a short form, but this just adds a couple sentences until that can be explored further.