### PR TITLE
Add `OBJECTSTORE_S3_SSE_C_KEY` environment variable to use S3 SSE-C encryption (server side encryption)

### DIFF
--- a/.config/s3.config.php
+++ b/.config/s3.config.php
@@ -23,6 +23,10 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
     )
   );
 
+  if (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
+    $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
+  }
+
   if (getenv('OBJECTSTORE_S3_KEY_FILE') && file_exists(getenv('OBJECTSTORE_S3_KEY_FILE'))) {
     $CONFIG['objectstore']['arguments']['key'] = trim(file_get_contents(getenv('OBJECTSTORE_S3_KEY_FILE')));
   } elseif (getenv('OBJECTSTORE_S3_KEY')) {

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ To use an external S3 compatible object store as primary storage, set the follow
 - `OBJECTSTORE_S3_LEGACYAUTH` (default: `false`): Not required for AWS S3
 - `OBJECTSTORE_S3_OBJECT_PREFIX` (default: `urn:oid:`): Prefix to prepend to the fileid
 - `OBJECTSTORE_S3_AUTOCREATE` (default: `true`): Create the container if it does not exist
+- `OBJECTSTORE_S3_SSE_C_KEY`: Server side encryption key - must be a base64 encoded string with a maximum length of 32 bytes
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) for more information.
 


### PR DESCRIPTION
Thanks to everyone who maintains this repo!

I recently learned I could pass in env vars for using S3 as the primary object store, but I was missing the encryption key.

This PR would add an environment variable called `OBJECTSTORE_S3_SSE_C_KEY` to the docs and if set, it will be used to provide the `sse_c_key` argument to the `$CONFIG` array in s3.config.php. If the user doesn't provide `OBJECTSTORE_S3_SSE_C_KEY`, we don't set `ss3_c_key`, because it has no default.

It's mentioned in the docs [here](https://docs.nextcloud.com/server/27/admin_manual/configuration_files/primary_storage.html?highlight=object#s3-sse-c-encryption-support):

> Nextcloud supports server side encryption, also known as [SSE-C](http://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html), with compatible S3 bucket provider. The encryption and decryption happens on the S3 bucket side with a key provided by the Nextcloud server.

> The key can be specified with the sse_c_key parameter which needs to be provided as a base64 encoded string with a maximum length of 32 bytes. A random key could be generated using the the following command:

```bash
openssl rand 32 | base64
```