### PR TITLE
feat(updater): Remove web based updater button for real

### DIFF
--- a/.config/upgrade-disable-web.config.php
+++ b/.config/upgrade-disable-web.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'upgrade.disable-web' => true,
+);


### PR DESCRIPTION
Web based updates already aren't used in the images, but the button remains enabled. The result is a button that returns an error when clicked and invalid instructions. This PR enables the relevant parameter [`upgrade.disable-web`](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#upgrade-disable-web) for this situation. It instructs Server to not display the update button and changes the instructions presented.

This is not a breaking change because this button already doesn't function in the images. This change merely reduces confusion and cuts down on help requests.

Note: A related PR in Server (nextcloud/server#41971) would make the instructions even clearer when `upgrade.disable-web` is used by downstream Docker images, but is not a dependency for this PR.