### PR TITLE
Update docker-entrypoint.sh - set hook folder find command to `max-depth 2`

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ run_path() {
     echo "=> Searching for scripts (*.sh) to run, located in the folder: ${hook_folder_path}"
 
     (
-        find "${hook_folder_path}" -type f -maxdepth 1 -iname '*.sh' -print | sort | while read -r script_file_path; do
+        find "${hook_folder_path}" -type f -maxdepth 2 -iname '*.sh' -print | sort | while read -r script_file_path; do
             if ! [ -x "${script_file_path}" ]; then
                 echo "==> The script \"${script_file_path}\" was skipped, because it didn't have the executable flag"
                 continue


### PR DESCRIPTION
This allows configMaps to be mounted into containers in the hook folders as scripts in Kubernetes. otherwise, this find command will never find a script mounted from a ConfigMap in kubernetes.

Please see more info on this here: https://github.com/nextcloud/docker/issues/763#issuecomment-1857453976

Merging this would unblock running occ commands in the post-installation and before-starting hook folders which would help out the nextcloud/helm repo a lot.

thanks for all your hard work maintaining this repo! :blue_heart: 