### PR TITLE
Improve handling of secret variables and files in autoconfig

### DIFF
--- a/.config/autoconfig.php
+++ b/.config/autoconfig.php
@@ -6,34 +6,62 @@ if (getenv('SQLITE_DATABASE')) {
     $AUTOCONFIG['dbtype'] = 'sqlite';
     $AUTOCONFIG['dbname'] = getenv('SQLITE_DATABASE');
     $autoconfig_enabled = true;
-} elseif (getenv('MYSQL_DATABASE_FILE') && getenv('MYSQL_USER_FILE') && getenv('MYSQL_PASSWORD_FILE') && getenv('MYSQL_HOST')) {
+} elseif (getenv('MYSQL_HOST') && (getenv('MYSQL_DATABASE') || getenv('MYSQL_DATABASE_FILE')) && (getenv('MYSQL_USER') || getenv('MYSQL_USER_FILE')) && (getenv('MYSQL_PASSWORD') || getenv('MYSQL_PASSWORD_FILE'))) {
+    $autoconfig_enabled = true;
     $AUTOCONFIG['dbtype'] = 'mysql';
-    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_DATABASE_FILE')));
-    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
-    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
     $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
+
+    if (getenv('MYSQL_USER_FILE') && file_exists(getenv('MYSQL_USER_FILE'))) {
+        $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('MYSQL_USER_FILE')));
+    } elseif (getenv('MYSQL_DATABASE')) {
+        $AUTOCONFIG['dbname'] = getenv('MYSQL_DATABASE');
+    } else {
+        $autoconfig_enabled = false;
+    }
+
+    if (getenv('POSTGRES_USER_FILE') && file_exists(getenv('POSTGRES_USER_FILE'))) {
+        $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
+    } elseif (getenv('MYSQL_USER')) {
+        $AUTOCONFIG['dbuser'] = getenv('MYSQL_USER');
+    } else {
+        $autoconfig_enabled = false;
+    }
+
+    if (getenv('MYSQL_PASSWORD_FILE') && file_exists(getenv('MYSQL_PASSWORD_FILE'))) {
+        $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('MYSQL_PASSWORD_FILE')));
+    } elseif (getenv('MYSQL_PASSWORD')) {
+        $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
+    } else {
+        $autoconfig_enabled = false;
+    }
+} elseif (getenv('POSTGRES_HOST') && (getenv('POSTGRES_DB') || getenv('POSTGRES_DB_FILE')) && (getenv('POSTGRES_USER') || getenv('POSTGRES_USER_FILE')) && (getenv('POSTGRES_PASSWORD') || getenv('POSTGRES_PASSWORD_FILE'))) {
     $autoconfig_enabled = true;
-} elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'mysql';
-    $AUTOCONFIG['dbname'] = getenv('MYSQL_DATABASE');
-    $AUTOCONFIG['dbuser'] = getenv('MYSQL_USER');
-    $AUTOCONFIG['dbpass'] = getenv('MYSQL_PASSWORD');
-    $AUTOCONFIG['dbhost'] = getenv('MYSQL_HOST');
-    $autoconfig_enabled = true;
-} elseif (getenv('POSTGRES_DB_FILE') && getenv('POSTGRES_USER_FILE') && getenv('POSTGRES_PASSWORD_FILE') && getenv('POSTGRES_HOST')) {
     $AUTOCONFIG['dbtype'] = 'pgsql';
-    $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
-    $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
-    $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
     $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
-    $autoconfig_enabled = true;
-} elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
-    $AUTOCONFIG['dbtype'] = 'pgsql';
-    $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
-    $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
-    $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
-    $AUTOCONFIG['dbhost'] = getenv('POSTGRES_HOST');
-    $autoconfig_enabled = true;
+
+    if (getenv('POSTGRES_DB_FILE') && file_exists(getenv('POSTGRES_DB_FILE'))) {
+        $AUTOCONFIG['dbname'] = trim(file_get_contents(getenv('POSTGRES_DB_FILE')));
+    } elseif (getenv('POSTGRES_DB')) {
+        $AUTOCONFIG['dbname'] = getenv('POSTGRES_DB');
+    } else {
+        $autoconfig_enabled = false;
+    }
+
+    if (getenv('POSTGRES_USER_FILE') && file_exists(getenv('POSTGRES_USER_FILE'))) {
+        $AUTOCONFIG['dbuser'] = trim(file_get_contents(getenv('POSTGRES_USER_FILE')));
+    } elseif (getenv('POSTGRES_USER')) {
+        $AUTOCONFIG['dbuser'] = getenv('POSTGRES_USER');
+    } else {
+        $autoconfig_enabled = false;
+    }
+
+    if (getenv('POSTGRES_PASSWORD_FILE') && file_exists(getenv('POSTGRES_PASSWORD_FILE'))) {
+        $AUTOCONFIG['dbpass'] = trim(file_get_contents(getenv('POSTGRES_PASSWORD_FILE')));
+    } elseif (getenv('POSTGRES_PASSWORD')) {
+        $AUTOCONFIG['dbpass'] = getenv('POSTGRES_PASSWORD');
+    } else {
+        $autoconfig_enabled = false;
+    }
 }
 
 if ($autoconfig_enabled) {


### PR DESCRIPTION
In the recent state, the autoconfig feature required either all database secrets to be passed as environment variables, or all to be passed as secret files, but didn't allow to use a mix of these variants, e.g. passing the database user and name as environment variables, and only the password as a file.

This is now fixed and allows working with database values the same way, as the Postgres and MySQL/MariaDB images do; with mixed variants also.