### PR TITLE
Fix/remove versions from examples

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/apache/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mariadb:10.6

--- a/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mariadb:10.6

--- a/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/apache/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine

--- a/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/postgres/fpm/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mariadb:10.6

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mariadb:10.6

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine


### PR DESCRIPTION
https://github.com/nextcloud/docker/issues/2194

I think this PR is necessary because without this change users are shown a warning:`WARN[0000] docker-compose.yml: 'version' is obsolete`.

From my perspective, many self-hosters are not experts in Docker and often use it as a way to make setting up services easier. The provided example documents are valuable to these users for this reason.

Having warnings show in the terminal or console when running docker compose commands might affect how users think and feel about the software that they are running. From my perspective, these types of users seem to expect an out-of-the-box working set up with example files like these.

For that reason, instead of running in [loose mode][1], I recommend simply removing the version name from the example yamls.

[1]: https://github.com/compose-spec/compose-spec/blob/master/01-status.md#requirements-and-optional-attributes