### PR TITLE
Documentation and examples update for use with docker compose v2

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
@@ -1,10 +1,12 @@
-version: '3'
-
 services:
   db:
-    image: mariadb:10.6
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    image: mariadb:10.8.2
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/mysql:Z
     environment:
@@ -21,6 +23,10 @@ services:
   app:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     ports:
       - 127.0.0.1:8080:80
     volumes:
@@ -37,6 +43,10 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh

--- a/.examples/docker-compose/insecure/mariadb/fpm/compose.yaml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/compose.yaml
@@ -1,10 +1,12 @@
-version: '3'
-
 services:
   db:
-    image: mariadb:10.6
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    image: mariadb:10.8.2
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/mysql:Z
     environment:
@@ -21,6 +23,10 @@ services:
   app:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
@@ -35,6 +41,10 @@ services:
   web:
     build: ./web
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     ports:
       - 127.0.0.1:8080:80
     volumes:
@@ -45,6 +55,10 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/Dockerfile
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY mime.types /etc/nginx/mime.types

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/mime.types
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/mime.types
@@ -1,0 +1,99 @@
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    text/javascript                           mjs js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -162,22 +162,8 @@ http {
             fastcgi_max_temp_file_size 0;
         }
 
-        # Javascript mimetype fixes for nginx
-        # Note: The block below should be removed, and the js|mjs section should be
-        # added to the block below this one. This is a temporary fix until Nginx 
-        # upstream fixes the js mime-type
-        location ~* \.(?:js|mjs)$ {
-            types { 
-                text/javascript js mjs;
-            } 
-            default_type "text/javascript";
-            try_files $uri /index.php$request_uri;
-            add_header Cache-Control "public, max-age=15778463, $asset_immutable";
-            access_log off;
-        }
-
         # Serve static files
-        location ~ \.(?:css|svg|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
+        location ~ \.(?:css|svg|js|mjs|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463, $asset_immutable";
             access_log off;     # Optional: Don't log access to assets

--- a/.examples/docker-compose/insecure/postgres/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/postgres/apache/compose.yaml
@@ -27,7 +27,7 @@ services:
     volumes:
       - nextcloud:/var/www/html:z
     environment:
-      - MYSQL_HOST=db
+      - POSTGRES_HOST=db
       - REDIS_HOST=redis
     env_file:
       - db.env

--- a/.examples/docker-compose/insecure/postgres/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/postgres/apache/compose.yaml
@@ -1,9 +1,11 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/postgresql/data:Z
     env_file:
@@ -16,12 +18,16 @@ services:
   app:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     ports:
       - 127.0.0.1:8080:80
     volumes:
       - nextcloud:/var/www/html:z
     environment:
-      - POSTGRES_HOST=db
+      - MYSQL_HOST=db
       - REDIS_HOST=redis
     env_file:
       - db.env
@@ -32,6 +38,10 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh

--- a/.examples/docker-compose/insecure/postgres/fpm/compose.yaml
+++ b/.examples/docker-compose/insecure/postgres/fpm/compose.yaml
@@ -1,11 +1,13 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
-      - db:/var/lib/postgresql/data:z
+      - db:/var/lib/postgresql/data:Z
     env_file:
       - db.env
 
@@ -16,6 +18,10 @@ services:
   app:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
@@ -30,6 +36,10 @@ services:
   web:
     build: ./web
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     ports:
       - 127.0.0.1:8080:80
     volumes:
@@ -40,6 +50,10 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh

--- a/.examples/docker-compose/insecure/postgres/fpm/web/Dockerfile
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY mime.types /etc/nginx/mime.types

--- a/.examples/docker-compose/insecure/postgres/fpm/web/mime.types
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/mime.types
@@ -1,0 +1,99 @@
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    text/javascript                           mjs js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/nginx.conf
@@ -162,21 +162,8 @@ http {
             fastcgi_max_temp_file_size 0;
         }
 
-        # Javascript mimetype fixes for nginx
-        # Note: The block below should be removed, and the js|mjs section should be
-        # added to the block below this one. This is a temporary fix until Nginx 
-        # upstream fixes the js mime-type
-        location ~* \.(?:js|mjs)$ {
-            types { 
-                text/javascript js mjs;
-            } 
-            try_files $uri /index.php$request_uri;
-            add_header Cache-Control "public, max-age=15778463, $asset_immutable";
-            access_log off;
-        }
-
         # Serve static files
-        location ~ \.(?:css|svg|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
+        location ~ \.(?:css|svg|js|mjs|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463, $asset_immutable";
             access_log off;     # Optional: Don't log access to assets

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/compose.yaml
@@ -1,10 +1,12 @@
-version: '3'
-
 services:
   db:
-    image: mariadb:10.6
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    image: mariadb:10.8.2
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/mysql:Z
     environment:
@@ -19,11 +21,18 @@ services:
     restart: always
 
   app:
-    image: nextcloud:fpm-alpine
+    image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
+      - VIRTUAL_HOST=
+      - LETSENCRYPT_HOST=
+      - LETSENCRYPT_EMAIL=
       - MYSQL_HOST=db
       - REDIS_HOST=redis
     env_file:
@@ -31,25 +40,21 @@ services:
     depends_on:
       - db
       - redis
-
-  web:
-    build: ./web
-    restart: always
-    volumes:
-      - nextcloud:/var/www/html:z,ro
-    environment:
-      - VIRTUAL_HOST=
-      - LETSENCRYPT_HOST=
-      - LETSENCRYPT_EMAIL=
-    depends_on:
-      - app
+      # Added proxy container dependency below. 
+      # It is unclear on when or why it happens, but sometimes NC manages to start before the proxy 
+      #  and it breaks for whatever weird reason resulting in the need of manual proxy container restart.
+      - proxy
     networks:
       - proxy-tier
       - default
 
   cron:
-    image: nextcloud:fpm-alpine
+    image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh
@@ -60,15 +65,20 @@ services:
   proxy:
     build: ./proxy
     restart: always
+    # Logging to syslog, it's best when combining with fail2ban on the host.
+    logging:
+      driver: "syslog"
     ports:
       - 80:80
       - 443:443
     labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     volumes:
-      - certs:/etc/nginx/certs:z,ro
+      - conf.d:/etc/nginx/conf.d:z
+      - certs:/etc/nginx/certs:ro:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
+      - dhparam:/etc/nginx/dhparam:z
       - /var/run/docker.sock:/tmp/docker.sock:z,ro
     networks:
       - proxy-tier
@@ -76,9 +86,16 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+    environment:
+      - DEFAULT_EMAIL=
     volumes:
       - certs:/etc/nginx/certs:z
       - acme:/etc/acme.sh:z
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/var/run/docker.sock:z,ro
@@ -109,6 +126,8 @@ volumes:
   acme:
   vhost.d:
   html:
+  dhparam:
+  conf.d:
 
 networks:
   proxy-tier:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/compose.yaml
@@ -1,11 +1,18 @@
-version: '3'
-
 services:
   db:
-    image: postgres:alpine
+    image: mariadb:10.8.2
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
-      - db:/var/lib/postgresql/data:Z
+      - db:/var/lib/mysql:Z
+    environment:
+      - MYSQL_ROOT_PASSWORD=
+      - MARIADB_AUTO_UPGRADE=1
+      - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:
       - db.env
 
@@ -16,20 +23,29 @@ services:
   app:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
-      - POSTGRES_HOST=db
+      - MYSQL_HOST=db
       - REDIS_HOST=redis
     env_file:
       - db.env
     depends_on:
       - db
       - redis
+      - proxy
 
   web:
     build: ./web
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z,ro
     environment:
@@ -45,6 +61,10 @@ services:
   cron:
     image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh
@@ -55,14 +75,17 @@ services:
   proxy:
     build: ./proxy
     restart: always
+    logging:
+      driver: "syslog"
     ports:
       - 80:80
       - 443:443
     labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     volumes:
       - certs:/etc/nginx/certs:z,ro
       - vhost.d:/etc/nginx/vhost.d:z
+      - conf.d:/etc/nginx/conf.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/tmp/docker.sock:z,ro
     networks:
@@ -71,9 +94,16 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+    environment:
+      - DEFAULT_EMAIL=
     volumes:
       - certs:/etc/nginx/certs:z
       - acme:/etc/acme.sh:z
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/var/run/docker.sock:z,ro
@@ -103,6 +133,7 @@ volumes:
   certs:
   acme:
   vhost.d:
+  conf.d:
   html:
 
 networks:

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY mime.types /etc/nginx/mime.types

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/mime.types
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/mime.types
@@ -1,0 +1,99 @@
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    text/javascript                           mjs js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -162,21 +162,8 @@ http {
             fastcgi_max_temp_file_size 0;
         }
 
-        # Javascript mimetype fixes for nginx
-        # Note: The block below should be removed, and the js|mjs section should be
-        # added to the block below this one. This is a temporary fix until Nginx 
-        # upstream fixes the js mime-type
-        location ~* \.(?:js|mjs)$ {
-            types { 
-                text/javascript js mjs;
-            } 
-            try_files $uri /index.php$request_uri;
-            add_header Cache-Control "public, max-age=15778463, $asset_immutable";
-            access_log off;
-        }
-
         # Serve static files
-        location ~ \.(?:css|svg|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
+        location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463, $asset_immutable";
             access_log off;     # Optional: Don't log access to assets

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/compose.yaml
@@ -1,9 +1,11 @@
-version: '3'
-
 services:
   db:
     image: postgres:alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/postgresql/data:Z
     env_file:
@@ -16,6 +18,10 @@ services:
   app:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
@@ -29,6 +35,7 @@ services:
     depends_on:
       - db
       - redis
+      - proxy
     networks:
       - proxy-tier
       - default
@@ -36,6 +43,10 @@ services:
   cron:
     image: nextcloud:apache
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh
@@ -46,13 +57,16 @@ services:
   proxy:
     build: ./proxy
     restart: always
+    logging:
+      driver: "syslog"
     ports:
       - 80:80
       - 443:443
     labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     volumes:
-      - certs:/etc/nginx/certs:z,ro
+      - certs:/etc/nginx/certs:ro:z
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/tmp/docker.sock:z,ro
@@ -65,6 +79,7 @@ services:
     volumes:
       - certs:/etc/nginx/certs:z
       - acme:/etc/acme.sh:z
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/var/run/docker.sock:z,ro
@@ -94,6 +109,7 @@ volumes:
   certs:
   acme:
   vhost.d:
+  conf.d:
   html:
 
 networks:

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/compose.yaml
@@ -2,15 +2,14 @@ version: '3'
 
 services:
   db:
-    image: mariadb:10.6
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    image: postgres:alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
-      - db:/var/lib/mysql:Z
-    environment:
-      - MYSQL_ROOT_PASSWORD=
-      - MARIADB_AUTO_UPGRADE=1
-      - MARIADB_DISABLE_UPGRADE_BACKUP=1
+      - db:/var/lib/postgresql/data:Z
     env_file:
       - db.env
 
@@ -19,28 +18,50 @@ services:
     restart: always
 
   app:
-    image: nextcloud:apache
+    image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     environment:
-      - VIRTUAL_HOST=
-      - LETSENCRYPT_HOST=
-      - LETSENCRYPT_EMAIL=
-      - MYSQL_HOST=db
+      - POSTGRES_HOST=db
       - REDIS_HOST=redis
     env_file:
       - db.env
     depends_on:
       - db
       - redis
+      - proxy
+
+  web:
+    build: ./web
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+    volumes:
+      - nextcloud:/var/www/html:z,ro
+    environment:
+      - VIRTUAL_HOST=
+      - LETSENCRYPT_HOST=
+      - LETSENCRYPT_EMAIL=
+    depends_on:
+      - app
     networks:
       - proxy-tier
       - default
 
   cron:
-    image: nextcloud:apache
+    image: nextcloud:fpm-alpine
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - nextcloud:/var/www/html:z
     entrypoint: /cron.sh
@@ -51,13 +72,16 @@ services:
   proxy:
     build: ./proxy
     restart: always
+    logging:
+      driver: "syslog"
     ports:
       - 80:80
       - 443:443
     labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"
     volumes:
       - certs:/etc/nginx/certs:z,ro
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/tmp/docker.sock:z,ro
@@ -67,12 +91,19 @@ services:
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - certs:/etc/nginx/certs:z
       - acme:/etc/acme.sh:z
+      - conf.d:/etc/nginx/conf.d:z
       - vhost.d:/etc/nginx/vhost.d:z
       - html:/usr/share/nginx/html:z
       - /var/run/docker.sock:/var/run/docker.sock:z,ro
+    environment:
+      - DEFAULT_EMAIL=
     networks:
       - proxy-tier
     depends_on:
@@ -98,6 +129,7 @@ volumes:
   nextcloud:
   certs:
   acme:
+  conf.d:
   vhost.d:
   html:
 

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY mime.types /etc/nginx/mime.types

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/mime.types
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/mime.types
@@ -1,0 +1,99 @@
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    text/javascript                           mjs js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/nginx.conf
@@ -162,21 +162,8 @@ http {
             fastcgi_max_temp_file_size 0;
         }
 
-        # Javascript mimetype fixes for nginx
-        # Note: The block below should be removed, and the js|mjs section should be
-        # added to the block below this one. This is a temporary fix until Nginx 
-        # upstream fixes the js mime-type
-        location ~* \.(?:js|mjs)$ {
-            types { 
-                text/javascript js mjs;
-            } 
-            try_files $uri /index.php$request_uri;
-            add_header Cache-Control "public, max-age=15778463, $asset_immutable";
-            access_log off;
-        }
-
         # Serve static files
-        location ~ \.(?:css|svg|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
+        location ~ \.(?:css|svg|js|mjs|gif|png|jpg|ico|wasm|tflite|map|ogg|flac)$ {
             try_files $uri /index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463, $asset_immutable";
             access_log off;     # Optional: Don't log access to assets

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Check the [Nexcloud documentation](https://docs.nextcloud.com/server/latest/admi
 Keep in mind that once set, removing these environment variables won't remove these values from the configuration file, due to how Nextcloud merges configuration files together.
 
 # Running this image with docker compose
-The easiest way to get a fully featured and functional setup is using a `docker compose` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
+The easiest way to get a fully featured and functional setup is using a docker `compose.yaml` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
 
 At first, make sure you have chosen the right base image (fpm or apache) and added features you wanted (see below). In every case, you would want to add a database container and docker volumes to get easy access to your persistent data. When you want to have your server reachable from the internet, adding HTTPS-encryption is mandatory! See below for more information.
 
@@ -332,7 +332,7 @@ volumes:
 Then run `docker compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 ## Base version - FPM
-When using the FPM image, you need another container that acts as web server on port 80 and proxies the requests to the Nextcloud container. In this example a simple nginx container is combined with the Nextcloud-fpm image and a MariaDB database container. The data is stored in docker volumes. The nginx container also needs access to static files from your Nextcloud installation. It gets access to all the volumes mounted to Nextcloud via the `volumes_from` option. The configuration for nginx is stored in the configuration file `nginx.conf`, that is mounted into the container. An example can be found in the examples section [here](https://github.com/nextcloud/docker/tree/master/.examples).
+When using the FPM image, you need another container that acts as web server on port 80 and proxies the requests to the Nextcloud container. In this example a simple nginx container is combined with the Nextcloud-fpm image and a MariaDB database container. The data is stored in docker volumes. The nginx container also needs access to static files from your Nextcloud installation. It gets access to all the volumes mounted to Nextcloud via the `volumes` option. The configuration for nginx is stored in the configuration file `nginx.conf`, that is mounted into the container. An example can be found in the examples section [here](https://github.com/nextcloud/docker/tree/master/.examples).
 
 > [!WARNING]
 > This setup provides **no ssl encryption** and is intended to run behind a proxy.
@@ -519,7 +519,7 @@ RUN ...
 ```
 The [examples folder](https://github.com/nextcloud/docker/blob/master/.examples) gives a few examples on how to add certain functionalities, like including the cron job, smb-support or imap-authentication.
 
-If you use your own Dockerfile, you need to configure your docker compose file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the docker compose file)
+If you use your own Dockerfile, you need to configure your docker compose file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the docker `compose.yaml` file)
 
 ```yaml
   app:
@@ -564,8 +564,8 @@ The `--pull` option tells docker to look for new versions of the base image. The
 # Migrating an existing installation
 You're already using Nextcloud and want to switch to docker? Great! Here are some things to look out for:
 
-1. Define your whole Nextcloud infrastructure in a `docker compose` file and run it with `docker compose up -d` to get the base installation, volumes and database. Work from there.
-2. Restore your database from a mysqldump (db is the name of your database container)
+1. Define your whole Nextcloud infrastructure in a docker `compose.yaml` file and run it with `docker compose up -d` to get the base installation, volumes and database. Work from there.
+2. Restore your database from a mysqldump (db is the name of your database container / service name)
     - To import from a MySQL dump use the following commands
     ```console
     docker compose cp ./database.dmp db:/dmp
@@ -617,7 +617,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
         ```php
         'datadirectory' => '/var/www/html/data',
         ```
-4. Copy your data (`app` is the name of your Nextcloud container):
+4. Copy your data (`app` is the name of your Nextcloud container / service name):
     ```console
     docker compose cp ./data/ app:/var/www/html/
     docker compose exec app chown -R www-data:www-data /var/www/html/data
@@ -632,7 +632,7 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
     ```
 5. Copy only the custom apps you use (or simply redownload them from the web interface):
     ```console
-    docker compose cp ./custom_apps/ nextcloud_data:/var/www/html/
+    docker compose cp ./custom_apps/ app:/var/www/html/
     docker compose exec app chown -R www-data:www-data /var/www/html/custom_apps
     ```
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 
 ## Using the fpm image
-To use the fpm image, you need an additional web server, such as [nginx](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html), that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want to use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker-compose` file). In both cases you don't want to map the fpm port to your host.
+To use the fpm image, you need an additional web server, such as [nginx](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html), that can proxy http-request to the fpm-port of the container. For fpm connection this container exposes port 9000. In most cases, you might want to use another container or your host as proxy. If you use your host you can address your Nextcloud container directly on port 9000. If you use another container, make sure that you add them to the same docker network (via `docker run --network <NAME> ...` or a `docker compose` file). In both cases you don't want to map the fpm port to your host.
 
 ```console
 $ docker run -d nextcloud:fpm
 ```
 
-As the fastCGI-Process is not capable of serving static files (style sheets, images, ...), the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the [docker-compose section](#running-this-image-with-docker-compose).
+As the fastCGI-Process is not capable of serving static files (style sheets, images, ...), the webserver needs access to these files. This can be achieved with the `volumes-from` option. You can find more information in the [docker compose section](#running-this-image-with-docker-compose).
 
 ## Using an external database
-By default, this container uses SQLite for data storage but the Nextcloud setup wizard (appears on first run) allows connecting to an existing MySQL/MariaDB or PostgreSQL database. You can also link a database container, e. g. `--link my-mysql:mysql`, and then use `mysql` as the database host on setup. More info is in the docker-compose section.
+By default, this container uses SQLite for data storage but the Nextcloud setup wizard (appears on first run) allows connecting to an existing MySQL/MariaDB or PostgreSQL database. You can also link a database container, e. g. `--link my-mysql:mysql`, and then use `mysql` as the database host on setup. More info is in the docker compose section.
 
 ## Persistent data
 The Nextcloud installation and all data beyond what lives in the database (file uploads, etc.) are stored in the [unnamed docker volume](https://docs.docker.com/engine/tutorials/dockervolumes/#adding-a-data-volume) volume `/var/www/html`. The docker daemon will store that data within the docker directory `/var/lib/docker/volumes/...`. That means your data is saved even if the container crashes, is stopped or deleted.
@@ -109,9 +109,9 @@ To use the [Nextcloud command-line interface](https://docs.nextcloud.com/server/
 ```console
 $ docker exec --user www-data CONTAINER_ID php occ
 ```
-or for docker-compose:
+or for docker compose:
 ```console
-$ docker-compose exec --user www-data app php occ
+$ docker compose exec --user www-data app php occ
 ```
 
 ## Auto configuration via environment variables
@@ -155,7 +155,7 @@ You might want to make sure the htaccess is up to date after each container upda
 
 - `NEXTCLOUD_INIT_HTACCESS` (not set by default) Set it to true to enable run `occ maintenance:update:htaccess` after container initialization.
 
-If you want to use Redis you have to create a separate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker-compose file. To inform Nextcloud about the Redis container, pass in the following parameters:
+If you want to use Redis you have to create a separate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker compose file. To inform Nextcloud about the Redis container, pass in the following parameters:
 
 - `REDIS_HOST` (not set by default) Name of Redis container
 - `REDIS_HOST_PORT` (default: `6379`) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
@@ -270,42 +270,51 @@ Check the [Nexcloud documentation](https://docs.nextcloud.com/server/latest/admi
 
 Keep in mind that once set, removing these environment variables won't remove these values from the configuration file, due to how Nextcloud merges configuration files together.
 
-# Running this image with docker-compose
-The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
+# Running this image with docker compose
+The easiest way to get a fully featured and functional setup is using a `docker compose` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
 
 At first, make sure you have chosen the right base image (fpm or apache) and added features you wanted (see below). In every case, you would want to add a database container and docker volumes to get easy access to your persistent data. When you want to have your server reachable from the internet, adding HTTPS-encryption is mandatory! See below for more information.
 
 ## Base version - apache
-This version will use the apache image and add a mariaDB container. The volumes are set to keep your data persistent. This setup provides **no ssl encryption** and is intended to run behind a proxy.
+This version will use the apache image and add a mariaDB container. The volumes are set to keep your data persistent. 
+> [!WARNING]
+> This setup provides **no ssl encryption** and is intended to run behind a proxy.
 
 Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` variables before you run this setup.
 
 ```yaml
-version: '2'
-
-volumes:
-  nextcloud:
-  db:
-
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:10.8.2
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     volumes:
       - db:/var/lib/mysql
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     environment:
       - MYSQL_ROOT_PASSWORD=
       - MYSQL_PASSWORD=
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
 
+  redis:
+    image: redis:alpine
+    restart: always
+
   app:
     image: nextcloud
     restart: always
     ports:
       - 8080:80
-    links:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+    depends_on:
+      - redis
       - db
     volumes:
       - nextcloud:/var/www/html
@@ -315,41 +324,52 @@ services:
       - MYSQL_USER=nextcloud
       - MYSQL_HOST=db
 
+volumes:
+  nextcloud:
+  db:
 ```
 
-Then run `docker-compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
+Then run `docker compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 ## Base version - FPM
 When using the FPM image, you need another container that acts as web server on port 80 and proxies the requests to the Nextcloud container. In this example a simple nginx container is combined with the Nextcloud-fpm image and a MariaDB database container. The data is stored in docker volumes. The nginx container also needs access to static files from your Nextcloud installation. It gets access to all the volumes mounted to Nextcloud via the `volumes_from` option. The configuration for nginx is stored in the configuration file `nginx.conf`, that is mounted into the container. An example can be found in the examples section [here](https://github.com/nextcloud/docker/tree/master/.examples).
 
-As this setup does **not include encryption**, it should be run behind a proxy.
+> [!WARNING]
+> This setup provides **no ssl encryption** and is intended to run behind a proxy.
 
 Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` variables before you run this setup.
 
 ```yaml
-version: '2'
-
-volumes:
-  nextcloud:
-  db:
-
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:10.8.2
     restart: always
-    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     volumes:
       - db:/var/lib/mysql
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     environment:
       - MYSQL_ROOT_PASSWORD=
       - MYSQL_PASSWORD=
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
 
+  redis:
+    image: redis:alpine
+    restart: always
+
   app:
     image: nextcloud:fpm
     restart: always
-    links:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+    depends_on:
+      - redis
       - db
     volumes:
       - nextcloud:/var/www/html
@@ -364,25 +384,31 @@ services:
     restart: always
     ports:
       - 8080:80
-    links:
+    depends_on:
       - app
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     volumes_from:
       - app
+
+volumes:
+  nextcloud:
+  db:
 ```
 
-Then run `docker-compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
+Then run `docker compose up -d`, now you can access Nextcloud at http://localhost:8080/ from your host system.
 
 # Docker Secrets
 As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to the previously listed environment variables, causing the initialization script to load the values for those variables from files present in the container. In particular, this can be used to load passwords from Docker secrets stored in `/run/secrets/<secret_name>` files. For example:
 ```yaml
-version: '3.2'
-
 services:
   db:
     image: postgres
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     volumes:
       - db:/var/lib/postgresql/data
     environment:
@@ -393,10 +419,17 @@ services:
       - postgres_db
       - postgres_password
       - postgres_user
+  redis:
+    image: redis:alpine
+    restart: always
 
   app:
     image: nextcloud
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
     ports:
       - 8080:80
     volumes:
@@ -409,6 +442,7 @@ services:
       - NEXTCLOUD_ADMIN_PASSWORD_FILE=/run/secrets/nextcloud_admin_password
       - NEXTCLOUD_ADMIN_USER_FILE=/run/secrets/nextcloud_admin_user
     depends_on:
+      - redis
       - db
     secrets:
       - nextcloud_admin_password
@@ -446,10 +480,10 @@ There are many different possibilities to introduce encryption depending on your
 
 We recommend using a reverse proxy in front of your Nextcloud installation. Your Nextcloud will only be reachable through the proxy, which encrypts all traffic to the clients. You can mount your manually generated certificates to the proxy or use a fully automated solution which generates and renews the certificates for you.
 
-In our [examples](https://github.com/nextcloud/docker/tree/master/.examples) section we have an example for a fully automated setup using a reverse proxy, a container for [Let's Encrypt](https://letsencrypt.org/) certificate handling, database and Nextcloud. It uses the popular [nginx-proxy](https://github.com/jwilder/nginx-proxy) and [docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) containers. Please check the according documentations before using this setup.
+In our [examples](https://github.com/nextcloud/docker/tree/master/.examples) section we have an example for a fully automated setup using a reverse proxy, a container for [Let's Encrypt](https://letsencrypt.org/) certificate handling, database and Nextcloud. It uses the popular [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) and [acme-companion](https://github.com/nginx-proxy/acme-companion) containers. Please check the according documentations before using this setup.
 
 # First use
-When you first access your Nextcloud, the setup wizard will appear and ask you to choose an administrator account username, password and the database connection. For the database use `db` as host and `nextcloud` as table and user name. Also enter the password you chose in your `docker-compose.yml` file.
+When you first access your Nextcloud, the setup wizard will appear and ask you to choose an administrator account username, password and the database connection. For the database use `db` as host and `nextcloud` as table and user name. Also enter the password you chose in your `compose.yaml` file.
 
 # Update to a newer version
 Updating the Nextcloud container is done by pulling the new image, throwing away the old container and starting the new one.
@@ -466,11 +500,11 @@ $ docker run <OPTIONS> -d nextcloud
 ```
 Beware that you have to run the same command with the options that you used to initially start your Nextcloud. That includes  volumes, port mapping.
 
-When using docker-compose your compose file takes care of your configuration, so you just have to run:
+When using docker compose your compose file takes care of your configuration, so you just have to run:
 
 ```console
-$ docker-compose pull
-$ docker-compose up -d
+$ docker compose pull
+$ docker compose up -d
 ```
 
 
@@ -485,13 +519,13 @@ RUN ...
 ```
 The [examples folder](https://github.com/nextcloud/docker/blob/master/.examples) gives a few examples on how to add certain functionalities, like including the cron job, smb-support or imap-authentication.
 
-If you use your own Dockerfile, you need to configure your docker-compose file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the docker-compose file)
+If you use your own Dockerfile, you need to configure your docker compose file accordingly. Switch out the `image` option with `build`. You have to specify the path to your Dockerfile. (in the example it's in the same directory next to the docker compose file)
 
 ```yaml
   app:
     build: .
     restart: always
-    links:
+    depends_on:
       - db
     volumes:
       - data:/var/www/html/data
@@ -519,10 +553,10 @@ docker build -t your-name --pull .
 docker run -d your-name
 ```
 
-or for docker-compose:
+or for docker compose:
 ```console
-docker-compose build --pull
-docker-compose up -d
+docker compose build --pull
+docker compose up -d
 ```
 
 The `--pull` option tells docker to look for new versions of the base image. Then the build instructions inside your `Dockerfile` are run on top of the new image.
@@ -530,19 +564,19 @@ The `--pull` option tells docker to look for new versions of the base image. The
 # Migrating an existing installation
 You're already using Nextcloud and want to switch to docker? Great! Here are some things to look out for:
 
-1. Define your whole Nextcloud infrastructure in a `docker-compose` file and run it with `docker-compose up -d` to get the base installation, volumes and database. Work from there.
-2. Restore your database from a mysqldump (nextcloud\_db\_1 is the name of your db container)
+1. Define your whole Nextcloud infrastructure in a `docker compose` file and run it with `docker compose up -d` to get the base installation, volumes and database. Work from there.
+2. Restore your database from a mysqldump (db is the name of your database container)
     - To import from a MySQL dump use the following commands
     ```console
-    docker cp ./database.dmp nextcloud_db_1:/dmp
-    docker-compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
-    docker-compose exec db rm /dmp
+    docker compose cp ./database.dmp db:/dmp
+    docker compose exec db sh -c "mysql --user USER --password PASSWORD nextcloud < /dmp"
+    docker compose exec db rm /dmp
     ```
     - To import from a PostgreSQL dump use to following commands
     ```console
-    docker cp ./database.dmp nextcloud_db_1:/dmp
-    docker-compose exec db sh -c "psql -U USER --set ON_ERROR_STOP=on nextcloud < /dmp"
-    docker-compose exec db rm /dmp
+    docker compose cp ./database.dmp db:/dmp
+    docker compose exec db sh -c "psql -U USER --set ON_ERROR_STOP=on nextcloud < /dmp"
+    docker compose exec db rm /dmp
     ```
 3. Edit your config.php
     1. Set database connection
@@ -583,14 +617,14 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
         ```php
         'datadirectory' => '/var/www/html/data',
         ```
-4. Copy your data (nextcloud_app_1 is the name of your Nextcloud container):
+4. Copy your data (`app` is the name of your Nextcloud container):
     ```console
-    docker cp ./data/ nextcloud_app_1:/var/www/html/
-    docker-compose exec app chown -R www-data:www-data /var/www/html/data
-    docker cp ./theming/ nextcloud_app_1:/var/www/html/
-    docker-compose exec app chown -R www-data:www-data /var/www/html/theming
-    docker cp ./config/config.php nextcloud_app_1:/var/www/html/config
-    docker-compose exec app chown -R www-data:www-data /var/www/html/config
+    docker compose cp ./data/ app:/var/www/html/
+    docker compose exec app chown -R www-data:www-data /var/www/html/data
+    docker compose cp ./theming/ app:/var/www/html/
+    docker compose exec app chown -R www-data:www-data /var/www/html/theming
+    docker compose cp ./config/config.php napp:/var/www/html/config
+    docker compose exec app chown -R www-data:www-data /var/www/html/config
     ```
     If you want to preserve the metadata of your files like timestamps, copy the data directly on the host to the named volume using plain `cp` like this:
     ```console
@@ -598,8 +632,8 @@ You're already using Nextcloud and want to switch to docker? Great! Here are som
     ```
 5. Copy only the custom apps you use (or simply redownload them from the web interface):
     ```console
-    docker cp ./custom_apps/ nextcloud_data:/var/www/html/
-    docker-compose exec app chown -R www-data:www-data /var/www/html/custom_apps
+    docker compose cp ./custom_apps/ nextcloud_data:/var/www/html/
+    docker compose exec app chown -R www-data:www-data /var/www/html/custom_apps
     ```
 
 # Questions / Issues


### PR DESCRIPTION
Howdy,

I noticed #2194 and the PR but there are more problems with the examples than just the `version` parameter. Docker changed the file name requirements too, changed the command and some of the syntax, jwilder's proxy is now part of nginx-proxy and more. This PR addresses those changes, and few others as well.

What was changed: 
1) Docs:  ( README.MD ) have commands, file names and examples updated everywhere. Minor edits to match the examples section and links.

2) Files: All `docker-compose.yml` files are renamed to `compose.yaml` files as per docker requirements.

3) Nginx configuration: I've been following the nginx mailing list since the problems we had with `mjs` file extension last year, and they wont fix it despite browsers expecting it as `text/javascript`. I have modified the examples to include mime-types from Nginx to the web container, and removed the "workaround" from the `nginx.conf` file to keep it as consistent as possible with the official Nextcloud docs. Effectively there is no difference from end user point of view. 

4) MariaDB: - Over the years we have several instances running using MariaDB and experience shows that 10.8.2 works better than 10.6 with recent versions of Nextcloud. I fully understand that it's not LTS release but we had several random problems with 10.6 that caused larger downtimes and then we switched to 10.8.2 in production, no issues whatsoever since then. It is also intentional that I didn't go newer than 10.8.2 because I cannot "promote" something to people that I hadn't tested properly myself. Considering majority of users copy-paste the examples and expect them to be working without issues - I believe this is better. 

5) Redis : I've added it on all the places it was missing. It should be there, all it does is speeding up nextcloud in general. 

6) Logging: Added a limit of 50 megabytes of log files on all containers. Recently I noticed that some instances had their log files grown to some absurd sizes (uptime for more than year without updates/downtime) and I've added that to the examples as well, for the same reason i changed the mariadb version. On few places(proxy containers, to be precise) I have intentionally added the logging driver to be `syslog`, because it works better with fail2ban on the host machine, it can't do any harm and it can hint to semi-sleeping sysadmins that the machine is under bots attack trying to log-in.

closes #2200 