### PR TITLE
Update Dockerfile-debian.template

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -107,9 +107,9 @@ RUN { \
     echo 'apc.enable_cli=1' >> "${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini"; \
     \
     { \
-        echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
-        echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
-        echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+        echo "memory_limit=${PHP_MEMORY_LIMIT}"; \
+        echo "upload_max_filesize=${PHP_UPLOAD_LIMIT}"; \
+        echo "post_max_size=${PHP_UPLOAD_LIMIT}"; \
     } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
     \
     mkdir /var/www/data; \


### PR DESCRIPTION
Fix Dockerfile template to properly evaluate environment variables in nextcloud.ini

The previous version of the Dockerfile used single quotes around the echo commands, preventing the proper evaluation of environment variables. This commit fixes the issue by replacing the single quotes with double quotes, allowing for the interpolation of environment variables. Now, the nextcloud.ini file correctly reflects the values of the PHP_MEMORY_LIMIT and PHP_UPLOAD_LIMIT environment variables.