### PR TITLE
fix(examples): `libmagickcore-6.q16-6-extra` is already in the image

### DIFF
--- a/.examples/README.md
+++ b/.examples/README.md
@@ -52,9 +52,6 @@ The required steps for each optional/recommended package that is not already in 
 #### ffmpeg
 `apt install ffmpeg`
 
-#### imagemagick SVG support
-`apt install libmagickcore-6.q16-6-extra`
-
 #### LibreOffice
 `apt install libreoffice`
 


### PR DESCRIPTION
Was added in #1789.

https://github.com/nextcloud/docker/blob/3b13c02caaaa229f7f3efa67c332765e17226bea/Dockerfile-debian.template#L11

No reason to include it in the examples listed as an optional package that isn't in the image.