### PR TITLE
Update redis.config.php

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -5,7 +5,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
       'host' => getenv('REDIS_HOST'),
-      'password' => (string) getenv('REDIS_HOST_PASSWORD'),
+      'password' => getenv('REDIS_HOST_PASSWORD_FILE') && file_exists(getenv('REDIS_HOST_PASSWORD_FILE')) ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );
 


### PR DESCRIPTION
Correctly set the redis password config from the REDIS_HOST_PASSWORD_FILE environment variable. Fix an issue similar to #1402 when using the REDIS_HOST_PASSWORD_FILE environment variable to provide the redis host secret.