### PR TITLE
Add pdf+other image preview support to alpine images after Alpine's packaging change

### DIFF
--- a/27/fpm-alpine/Dockerfile
+++ b/27/fpm-alpine/Dockerfile
@@ -6,6 +6,12 @@ RUN set -ex; \
     \
     apk add --no-cache \
         imagemagick \
+        imagemagick-pdf \
+        imagemagick-jpeg \
+        imagemagick-raw \
+        imagemagick-tiff \
+        imagemagick-heic \
+        imagemagick-webp \
         rsync \
     ; \
     \

--- a/28/fpm-alpine/Dockerfile
+++ b/28/fpm-alpine/Dockerfile
@@ -6,6 +6,12 @@ RUN set -ex; \
     \
     apk add --no-cache \
         imagemagick \
+        imagemagick-pdf \
+        imagemagick-jpeg \
+        imagemagick-raw \
+        imagemagick-tiff \
+        imagemagick-heic \
+        imagemagick-webp \
         rsync \
     ; \
     \

--- a/29/fpm-alpine/Dockerfile
+++ b/29/fpm-alpine/Dockerfile
@@ -6,6 +6,12 @@ RUN set -ex; \
     \
     apk add --no-cache \
         imagemagick \
+        imagemagick-pdf \
+        imagemagick-jpeg \
+        imagemagick-raw \
+        imagemagick-tiff \
+        imagemagick-heic \
+        imagemagick-webp \
         rsync \
     ; \
     \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -5,6 +5,12 @@ RUN set -ex; \
     \
     apk add --no-cache \
         imagemagick \
+        imagemagick-pdf \
+        imagemagick-jpeg \
+        imagemagick-raw \
+        imagemagick-tiff \
+        imagemagick-heic \
+        imagemagick-webp \
         rsync \
     ; \
     \


### PR DESCRIPTION
I'm also creating this PR to add PDF preview support, which doesn't work without the `imagemagick-pdf` package. This is in reference to https://github.com/nextcloud/docker/pull/2246#issuecomment-2190435512:

> But let's also create an issue now (or, better yet, WIP PR) to propose & firm up what others should also be added back in, in a follow-up[1].

> [1] We probably want to keep parity. Is there anything that doesn't belong or should we just load all of them back in to mirror the old packaging?

> Cc: @felix-egli

We could also combine this PR with https://github.com/nextcloud/docker/pull/2246 since we missed the release for `29.0.3` this time anyway. Open to either way, or if I misunderstood, please feel free to give me gentle feedback and I'll remedy what's needed! 🙏

Also open to adding additional packages. `svg` and `pdf` are just the file formats that stuck out to me from the beginning.