### PR TITLE
fix: Disabled app list stays empty due to missing `diffutils` on Alpine 

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,6 +41,8 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
     ; \
+    # Install diffutils to address diff dependencies issue
+    apk add --no-cache diffutils; \
     \
     docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \


### PR DESCRIPTION
Fixes #1911

**Description:**
This PR fixes issue #1911 by installing `diffutils` in alpine image and made change in the `Dockerfile-alpine.template`. This ensures that the disabled app list is populated correctly.

**Changes:**

- Updated `Dockerfile-alpine.template` to include `diffutils` in alpine docker image.

**Testing:**

- Built the Docker image using the modified Dockerfile.
- Verified that the issue with the empty disabled app list is resolved.

**Additional Notes:**

- This is my first contribution to this project. Please let me know if there are any changes or improvements needed. I personally use nextcloud in my home-server and its awesome