### PR TITLE
 Fix: Retry logic in entrypoint.sh for Nextcloud installation

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,6 +41,8 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
     ; \
+    # Install diffutils to address diff dependencies issue
+    apk add --no-cache diffutils; \
     \
     docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,8 +41,6 @@ RUN set -ex; \
         pcre-dev \
         postgresql-dev \
     ; \
-    # Install diffutils to address diff dependencies issue
-    apk add --no-cache diffutils; \
     \
     docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -225,7 +225,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                         echo "Starting nextcloud installation"
                         max_retries=10
                         try=0
-                        until run_as "php /var/www/html/occ maintenance:install $install_options" || [ "$try" -gt "$max_retries" ]
+                        until  [ "$try" -gt "$max_retries" ] || run_as "php /var/www/html/occ maintenance:install $install_options" 
                         do
                             echo "Retrying install..."
                             try=$((try+1))


### PR DESCRIPTION
**Description:**
This PR addresses a flaw in the retry logic in the `docker-entrypoint.sh` script for Nextcloud using Docker. The issue is retry mechanism to execute the installation command an extra time and potentially abort a successful installation.

**Changes Made:**

- Modified the retry condition in `docker-entrypoint.sh` to ensure the installation command does not execute an additional time and to prevent the abortion of a successful installation.

**Testing:**

- Verified that the retry logic correctly handles the installation without unnecessary retries.
- Confirmed that a successful installation is not aborted.