### PR TITLE
Add FORWARDED_FOR_HEADERS to the reverse-proxy config

### DIFF
--- a/.config/reverse-proxy.config.php
+++ b/.config/reverse-proxy.config.php
@@ -28,3 +28,8 @@ $trustedProxies = getenv('TRUSTED_PROXIES');
 if ($trustedProxies) {
   $CONFIG['trusted_proxies'] = array_filter(array_map('trim', explode(' ', $trustedProxies)));
 }
+
+$forwardedForHeaders = getenv('FORWARDED_FOR_HEADERS');
+if ($forwardedForHeaders) {
+  $CONFIG['forwarded_for_headers'] = array_filter(array_map('trim', explode(' ', $forwardedForHeaders)));
+}


### PR DESCRIPTION
Needed for reverse proxy configuration to show the real IP (especially needed for helm https://github.com/nextcloud/helm/pull/613) 

Also defined here: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/reverse_proxy_configuration.html#defining-trusted-proxies