### PR TITLE
Added docker env debug mode

### DIFF
--- a/28/apache/config/log.config.php
+++ b/28/apache/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}

--- a/28/fpm-alpine/config/log.config.php
+++ b/28/fpm-alpine/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}

--- a/28/fpm/config/log.config.php
+++ b/28/fpm/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}

--- a/29/apache/config/log.config.php
+++ b/29/apache/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}

--- a/29/fpm-alpine/config/log.config.php
+++ b/29/fpm-alpine/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}

--- a/29/fpm/config/log.config.php
+++ b/29/fpm/config/log.config.php
@@ -1,0 +1,6 @@
+<?php
+if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
+    $CONFIG = array (
+        'debug' => true,
+      );
+}


### PR DESCRIPTION
There doesn't seem to be an easy way to handle debug mode when running with docker, so it would be nice to add it.

I just added log.config.php to all config/ directory.

```php
<?php
if (getenv('NEXTCLOUD_DEGBUG_MODE') !== false) {
    $CONFIG = array (
        'debug' => true,
      );
}
```
