### PR TITLE
Adding support for DBINDEX redis config value in docker compose

### DIFF
--- a/29/apache/Dockerfile
+++ b/29/apache/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex; \
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
 ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_UPLOAD_LIMIT 512M
+ENV REDIS_DB_INDEX=0
 RUN set -ex; \
     \
     savedAptMark="$(apt-mark showmanual)"; \

--- a/29/apache/config/redis.config.php
+++ b/29/apache/config/redis.config.php
@@ -14,4 +14,8 @@ if (getenv('REDIS_HOST')) {
   } elseif (getenv('REDIS_HOST')[0] != '/') {
     $CONFIG['redis']['port'] = 6379;
   }
+  if (getenv('REDIS_DBINDEX') !== false) {
+    $CONFIG['redis']['dbindex'] = (int) getenv('REDIS_DBINDEX');
+  }
+
 }

--- a/29/apache/config/redis.config.php
+++ b/29/apache/config/redis.config.php
@@ -14,8 +14,8 @@ if (getenv('REDIS_HOST')) {
   } elseif (getenv('REDIS_HOST')[0] != '/') {
     $CONFIG['redis']['port'] = 6379;
   }
-  if (getenv('REDIS_DBINDEX') !== false) {
-    $CONFIG['redis']['dbindex'] = (int) getenv('REDIS_DBINDEX');
+  if (getenv('REDIS_DB_INDEX') !== false) {
+    $CONFIG['redis']['dbindex'] = (int) getenv('REDIS_DB_INDEX');
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ If you want to use Redis you have to create a separate [Redis](https://hub.docke
 - `REDIS_HOST` (not set by default) Name of Redis container
 - `REDIS_HOST_PORT` (default: `6379`) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
 - `REDIS_HOST_PASSWORD` (not set by default) Redis password
-- `REDIS_DBINDEX`(not set by default) Value for dbindex config value
+- `REDIS_DB_INDEX` (default: `0`) Value for dbindex config value
 
 The use of Redis is recommended to prevent file locking problems. See the examples for further instructions.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you want to use Redis you have to create a separate [Redis](https://hub.docke
 - `REDIS_HOST` (not set by default) Name of Redis container
 - `REDIS_HOST_PORT` (default: `6379`) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
 - `REDIS_HOST_PASSWORD` (not set by default) Redis password
+- `REDIS_DBINDEX`(not set by default) Value for dbindex config value
 
 The use of Redis is recommended to prevent file locking problems. See the examples for further instructions.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -114,15 +114,15 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             # check if redis host is an unix socket path
             if [ "$(echo "$REDIS_HOST" | cut -c1-1)" = "/" ]; then
               if [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"unix://${REDIS_HOST}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"unix://${REDIS_HOST}/${REDIS_DB_INDEX}?auth=${REDIS_HOST_PASSWORD}\""
               else
-                echo "session.save_path = \"unix://${REDIS_HOST}\""
+                echo "session.save_path = \"unix://${REDIS_HOST}/${REDIS_DB_INDEX}\""
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}/${REDIS_DB_INDEX}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}/${REDIS_DB_INDEX}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"


### PR DESCRIPTION
Currently, there is no support for adding dbindex config value ($CONFIG['redis']['dbindex']) within compose file. Even in manually updating or setting the value for a container, the changes aren't applied. This fixes the missing option.

