### PR TITLE
Disable absolute redirect

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/nginx.conf
@@ -10,6 +10,8 @@ events {
 
 
 http {
+    absolute_redirect off;
+    
     include mime.types;
     default_type  application/octet-stream;
     types {

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/nginx.conf
@@ -10,6 +10,8 @@ events {
 
 
 http {
+    absolute_redirect off;
+
     include mime.types;
     default_type  application/octet-stream;
     types {


### PR DESCRIPTION
Absolute redirect should be disabled. Currently, it only works by chance because the `web` container is listening on port 80.

If you try to change the port to something like 8080, the 301 redirect for things like caldav and carddav will be broken.