### PR TITLE
Enable TLS connection for Redis

### DIFF
--- a/28/apache/config/redis.config.php
+++ b/28/apache/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/28/apache/entrypoint.sh
+++ b/28/apache/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/28/fpm-alpine/config/redis.config.php
+++ b/28/fpm-alpine/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/28/fpm-alpine/entrypoint.sh
+++ b/28/fpm-alpine/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/28/fpm/config/redis.config.php
+++ b/28/fpm/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/28/fpm/entrypoint.sh
+++ b/28/fpm/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/29/apache/config/redis.config.php
+++ b/29/apache/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/29/apache/entrypoint.sh
+++ b/29/apache/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/29/fpm-alpine/config/redis.config.php
+++ b/29/fpm-alpine/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/29/fpm-alpine/entrypoint.sh
+++ b/29/fpm-alpine/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/29/fpm/config/redis.config.php
+++ b/29/fpm/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/29/fpm/entrypoint.sh
+++ b/29/fpm/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/30/apache/config/redis.config.php
+++ b/30/apache/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/30/apache/entrypoint.sh
+++ b/30/apache/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/30/fpm-alpine/config/redis.config.php
+++ b/30/fpm-alpine/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/30/fpm-alpine/entrypoint.sh
+++ b/30/fpm-alpine/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/30/fpm/config/redis.config.php
+++ b/30/fpm/config/redis.config.php
@@ -4,7 +4,7 @@ if (getenv('REDIS_HOST')) {
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'redis' => array(
-      'host' => getenv('REDIS_HOST'),
+      'host' => ($_ENV['REDIS_PROTOCOL'] ?? 'tcp') . "://" . getenv('REDIS_HOST'),
       'password' => getenv('REDIS_HOST_PASSWORD_FILE') ? trim(file_get_contents(getenv('REDIS_HOST_PASSWORD_FILE'))) : (string) getenv('REDIS_HOST_PASSWORD'),
     ),
   );

--- a/30/fpm/entrypoint.sh
+++ b/30/fpm/entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -120,9 +120,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
               fi
             # check if redis password has been set
             elif [ -n "${REDIS_HOST_PASSWORD+x}" ]; then
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}?auth=${REDIS_HOST_PASSWORD}\""
             else
-                echo "session.save_path = \"tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
+                echo "session.save_path = \"${REDIS_PROTOCOL:=tcp}://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}\""
             fi
             echo "redis.session.locking_enabled = 1"
             echo "redis.session.lock_retries = -1"


### PR DESCRIPTION
Hello!

This is a hopefully simple PR to allow users to configure Redis to connect to a TLS-enabled Redis endpoint. It proposes a new environment variable `REDIS_PROTOCOL` that can be passed to the container, and replaces all areas (that I found) where `tcp://` was either hard-coded or the assumed (omitted) default. All adjustments will continue to use `tcp` as the default if the env var isn't passed, so this shouldn't impact existing installations.

I don't do PR's very frequently so apologies if I missed something here, but I'm interested in thoughts/feedback!

Thank you!