### PR TITLE
fix(hooks): make the output more uniform an delineated

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,30 +24,30 @@ run_path() {
     local hook_folder_path="/docker-entrypoint-hooks.d/$1"
     local return_code=0
 
-    if ! [ -d "${hook_folder_path}" ]; then
-        echo "=> Skipping the folder \"${hook_folder_path}\", because it doesn't exist"
+    echo "=> Searching for hook scripts (*.sh) to run, located in the folder: ${hook_folder_path}"
+
+    if ! [ -d "${hook_folder_path}" ] || directory_empty "${hook_folder_path}"; then
+        echo "=> Skipping the hook folder \"${hook_folder_path}\", because it doesn't exist or is empty"
         return 0
     fi
-
-    echo "=> Searching for scripts (*.sh) to run, located in the folder: ${hook_folder_path}"
 
     (
         find "${hook_folder_path}" -maxdepth 1 -iname '*.sh' '(' -type f -o -type l ')' -print | sort | while read -r script_file_path; do
             if ! [ -x "${script_file_path}" ]; then
-                echo "==> The script \"${script_file_path}\" was skipped, because it didn't have the executable flag"
+                echo "==> The hook script \"${script_file_path}\" was skipped, because it didn't have the executable flag"
                 continue
             fi
 
-            echo "==> Running the script (cwd: $(pwd)): \"${script_file_path}\""
+            echo "==> Running the hook script (cwd: $(pwd)): \"${script_file_path}\""
 
             run_as "${script_file_path}" || return_code="$?"
 
             if [ "${return_code}" -ne "0" ]; then
-                echo "==> Failed at executing \"${script_file_path}\". Exit code: ${return_code}"
+                echo "==> Failed at executing hook script \"${script_file_path}\". Exit code: ${return_code}"
                 exit 1
             fi
 
-            echo "==> Finished the script: \"${script_file_path}\""
+            echo "==> Finished the hook script: \"${script_file_path}\""
         done
     )
 }


### PR DESCRIPTION
Previously:

- Some essentially similar hook folder states would result in different output (e.g. nonexistent versus empty folders)
- The completion of a given stage wasn't 100% delineated

With this PR, the broader hook handling output is more neutral/consistent while retaining detailed hints where appropriate about the state of things along the way.

Specifically:

- *Always* indicate when we're searching for scripts for a given stage
- Skip early if a given stage's folder is empty too 
- Always indicate when we're skipping (executing nothing for) a given stage + why
- Always delineate when we've completely finished executing all found scripts for given stage
- Add the term we use for this feature in our docs to the output ("hook")
- Minor language tweaks 

Tested with:

- Empty hook folders
- Nonexistent hook folders
- Scripts lacking exec permission in hook folder
- Non-`*.sh` files in hook folders
- Valid executable scripts in hook folder