### PR TITLE
fix: do not oversize jit_buffer_size

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -96,7 +96,7 @@ RUN { \
         echo 'opcache.save_comments=1'; \
         echo 'opcache.revalidate_freq=60'; \
         echo 'opcache.jit=1255'; \
-        echo 'opcache.jit_buffer_size=128M'; \
+        echo 'opcache.jit_buffer_size=8M'; \
     } > "${PHP_INI_DIR}/conf.d/opcache-recommended.ini"; \
     \
     echo 'apc.enable_cli=1' >> "${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -101,7 +101,7 @@ RUN { \
         echo 'opcache.save_comments=1'; \
         echo 'opcache.revalidate_freq=60'; \
         echo 'opcache.jit=1255'; \
-        echo 'opcache.jit_buffer_size=128M'; \
+        echo 'opcache.jit_buffer_size=8M'; \
     } > "${PHP_INI_DIR}/conf.d/opcache-recommended.ini"; \
     \
     echo 'apc.enable_cli=1' >> "${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini"; \


### PR DESCRIPTION
The opcache memory got full on my instance:

> The PHP OPcache module is not properly configured. The OPcache buffer is nearly full. To assure that all scripts can be hold in cache, it is recommended to apply "opcache.memory_consumption" to your PHP configuration with a value higher than "128"

It's the same problem that the one raised in #2352 , but a better solution seems to adjust `opcache.jit_buffer_size`.

This corresponds to the following change in the documentation: https://github.com/nextcloud/documentation/commit/538390d924a591a630b7b451da2fcd6c28dc21d2

> Single Nextcloud instances have shown to use less than 2 MiB of the configured JIT buffer size, so that 8 MiB is sufficient by a large margin. Using any larger value pre-occupies the `opcache.memory_consumption` accurdingly and 128 MiB would hence fill its default 128 MiB completely, without any benefit.
