### PR TITLE
Add REDIS_HOST_USER variable to specify a redis user

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -14,4 +14,8 @@ if (getenv('REDIS_HOST')) {
   } elseif (getenv('REDIS_HOST')[0] != '/') {
     $CONFIG['redis']['port'] = 6379;
   }
+
+  if (getenv('REDIS_HOST_USER') !== false) {
+    $CONFIG['redis']['user'] = (string) getenv('REDIS_HOST_USER');
+  }
 }

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ To use Redis for memory caching as well as PHP session storage, specify the foll
 
 - `REDIS_HOST` (not set by default) Name of Redis container
 - `REDIS_HOST_PORT` (default: `6379`) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
+- `REDIS_HOST_USER` (not set by default) Optional username for Redis, only use for external Redis servers that require a user.
 - `REDIS_HOST_PASSWORD` (not set by default) Redis password
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/caching_configuration.html) for more information.


### PR DESCRIPTION
Our setup requires a 'user' => 'TheRealRedisUser' entry in config.php. This environment variable would make that easier.