### PR TITLE
fix: make sure to fail rather than continue if rsync fails

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -172,12 +172,24 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
             fi
 
             rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
+            if [ "$?" -ne "0" ]; then
+                echo "Rsync failed. Giving up to be safe."
+                exit 1
+       	    fi
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+                    if [ "$?" -ne "0" ]; then
+                        echo "Rsync failed. Giving up to be safe."
+                        exit 1
+                    fi
                 fi
             done
             rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
+            if [ "$?" -ne "0" ]; then
+     		    echo "Rsync failed. Giving up to be safe."
+               exit 1
+       	    fi
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then


### PR DESCRIPTION
Ran across an in-the-wild environment where rsync was failing due to I/O disk errors, but initializing continued on anyhow. We should check the exit values and fail hard since it'll result in a broken installation (and may get overlooked until later depending on what files the errors occur on).

```
2025-01-13T15:13:04.250546270Z Initializing nextcloud 30.0.4.1 ...
2025-01-13T15:13:13.543136088Z rsync: [sender] read errors mapping "/usr/src/nextcloud/apps/text/js/pgsql-6nMyK_Wd.chunk.mjs.map": I/O error (5)
[...]
2025-01-13T15:13:13.791311797Z ERROR: apps/text/js/pgsql-6nMyK_Wd.chunk.mjs.map failed verification -- update discarded.
[...]
2025-01-13T15:13:18.615971825Z rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1338) [sender=3.3.0]
2025-01-13T15:13:18.903862977Z Initializing finished
2025-01-13T15:13:18.903916218Z New Nextcloud instance.
2025-01-13T15:13:18.913472340Z Installing with pgsql database
2025-01-13T15:13:18.913679471Z Starting Nextcloud installation...
```

Follow-up ideas:

- wrap in a function
- create a generic "run_this()` function that checks exit values for any commands

P.S. Should probably get more testing.