### PR TITLE
feature: configurable user ids

### DIFF
--- a/29/apache/entrypoint.sh
+++ b/29/apache/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/29/fpm-alpine/entrypoint.sh
+++ b/29/fpm-alpine/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/29/fpm/entrypoint.sh
+++ b/29/fpm/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/30/apache/entrypoint.sh
+++ b/30/apache/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/30/fpm-alpine/entrypoint.sh
+++ b/30/fpm-alpine/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/30/fpm/entrypoint.sh
+++ b/30/fpm/entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then

--- a/README.md
+++ b/README.md
@@ -172,7 +172,13 @@ The `--private` flag can also be specified, in order to output all configuration
 
 ## Auto configuration via environment variables
 
-The Nextcloud image supports auto configuration of the Nextcloud Server installation via environment variables. You can preconfigure everything that would otherwise be prompted for by the Nextcloud Installation Wizard (as well as a few other key parameters relevant to initial installation). 
+The Nextcloud image supports auto configuration via environment variables. You can preconfigure everything that would otherwise be prompted for by the Nextcloud Installation Wizard (as well as a few other key parameters relevant to initial installation).
+
+### User/Group Identifiers
+- `UID` - Set user ID for www-data user (optional)
+- `GID` - Set group ID for www-data group (optional)
+
+These optional variables allow you to match the container's www-data user/group IDs with your host system's user/group IDs for better file permission handling.
 
 ### Database parameters
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,6 +83,12 @@ if expr "$1" : "apache" 1>/dev/null; then
 fi
 
 if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UPDATE:-0}" -eq 1 ]; then
+    if [ -n "${UID}" ] && [ -n "${GID}" ]; then
+        echo "Updating www-data user/group IDs..."
+        groupmod -o -g "${GID}" www-data
+        usermod -o -u "${UID}" www-data
+    fi
+
     uid="$(id -u)"
     gid="$(id -g)"
     if [ "$uid" = '0' ]; then


### PR DESCRIPTION
Add support for configuring www-data user/group IDs via environment variables:
- `UID`: Set user ID for www-data user
- `GID`: Set group ID for www-data group

This allows matching container permissions with host system UIDs/GIDs for better file permission handling, especially useful in environments with shared storage or specific permission requirements.