### PR TITLE
feature: add ffmpeg

### DIFF
--- a/29/apache/Dockerfile
+++ b/29/apache/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        ffmpeg \
         busybox-static \
         bzip2 \
         libldap-common \

--- a/29/fpm-alpine/Dockerfile
+++ b/29/fpm-alpine/Dockerfile
@@ -5,6 +5,7 @@ FROM php:8.2-fpm-alpine3.21
 RUN set -ex; \
     \
     apk add --no-cache \
+        ffmpeg \
         imagemagick \
         imagemagick-pdf \
         imagemagick-jpeg \

--- a/29/fpm/Dockerfile
+++ b/29/fpm/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        ffmpeg \
         busybox-static \
         bzip2 \
         libldap-common \

--- a/30/apache/Dockerfile
+++ b/30/apache/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        ffmpeg \
         busybox-static \
         bzip2 \
         libldap-common \

--- a/30/fpm-alpine/Dockerfile
+++ b/30/fpm-alpine/Dockerfile
@@ -5,6 +5,7 @@ FROM php:8.2-fpm-alpine3.21
 RUN set -ex; \
     \
     apk add --no-cache \
+        ffmpeg \
         imagemagick \
         imagemagick-pdf \
         imagemagick-jpeg \

--- a/30/fpm/Dockerfile
+++ b/30/fpm/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        ffmpeg \
         busybox-static \
         bzip2 \
         libldap-common \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -4,6 +4,7 @@ FROM php:%%PHP_VERSION%%-%%VARIANT%%%%ALPINE_VERSION%%
 RUN set -ex; \
     \
     apk add --no-cache \
+        ffmpeg \
         imagemagick \
         imagemagick-pdf \
         imagemagick-jpeg \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -5,6 +5,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        ffmpeg \
         busybox-static \
         bzip2 \
         libldap-common \


### PR DESCRIPTION
It would be nice if I don't have to carry [my own](https://github.com/realies/nextcloud-docker) CI for this.

I understand the security considerations around preview generation mentioned in the [examples documentation](https://github.com/nextcloud/docker/tree/master/.examples#full).
However, I believe FFmpeg belongs in the base image alongside ImageMagick because:

1. It's already a recommended component in the official "full" example
2. Like ImageMagick, it's a core media processing dependency
3. Users can still disable preview generation for high-security deployments
4. Having it in the base image reduces duplicate CI efforts while maintaining the ability to control its usage

The change is minimal and follows the pattern of including essential media processing tools while letting administrators control their usage through Nextcloud's configuration.