### PR TITLE
Updated examples

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: MariaDB is an external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     command: --transaction-isolation=READ-COMMITTED
@@ -12,6 +14,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always

--- a/.examples/docker-compose/insecure/mariadb/fpm/compose.yaml
+++ b/.examples/docker-compose/insecure/mariadb/fpm/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: MariaDB is an external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     command: --transaction-isolation=READ-COMMITTED
@@ -12,6 +14,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -31,14 +35,17 @@ services:
       - db
       - redis
 
+  # Note: Nginx is an external service. You can find more information about the configuration here:
+  # https://hub.docker.com/_/nginx/
   web:
-    build: ./web
+    image: nginx:alpine
     restart: always
     ports:
       - 127.0.0.1:8080:80
     volumes:
+      - ./web/nginx.conf:/etc/nginx/nginx.conf:ro  # https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html
+      # NOTE: The `volumes` included below should match those of the `app` container (unless you know what you're doing)
       - nextcloud:/var/www/html:z,ro
-      # NOTE: The `volumes` included here should match those of the `app` container (unless you know what you're doing)
     depends_on:
       - app
 

--- a/.examples/docker-compose/insecure/mariadb/fpm/web/Dockerfile
+++ b/.examples/docker-compose/insecure/mariadb/fpm/web/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/.examples/docker-compose/insecure/postgres/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/postgres/apache/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: PostgreSQL is an external service. You can find more information about the configuration here:
+  # https://github.com/docker-library/docs/blob/master/postgres/README.md
   db:
     image: postgres:alpine
     restart: always
@@ -7,6 +9,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always

--- a/.examples/docker-compose/insecure/postgres/fpm/compose.yaml
+++ b/.examples/docker-compose/insecure/postgres/fpm/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: PostgreSQL is an external service. You can find more information about the configuration here:
+  # https://github.com/docker-library/docs/blob/master/postgres/README.md
   db:
     image: postgres:alpine
     restart: always
@@ -7,6 +9,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -26,14 +30,17 @@ services:
       - db
       - redis
 
+  # Note: Nginx is an external service. You can find more information about the configuration here:
+  # https://hub.docker.com/_/nginx/
   web:
-    build: ./web
+    image: nginx:alpine
     restart: always
     ports:
       - 127.0.0.1:8080:80
     volumes:
+      - ./web/nginx.conf:/etc/nginx/nginx.conf:ro  # https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html
+      # NOTE: The `volumes` included below should match those of the `app` container (unless you know what you're doing)
       - nextcloud:/var/www/html:z,ro
-      # NOTE: The `volumes` included here should match those of the `app` container (unless you know what you're doing)
     depends_on:
       - app
 

--- a/.examples/docker-compose/insecure/postgres/fpm/web/Dockerfile
+++ b/.examples/docker-compose/insecure/postgres/fpm/web/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: MariaDB is an external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     command: --transaction-isolation=READ-COMMITTED
@@ -12,6 +14,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -33,9 +37,6 @@ services:
     depends_on:
       - db
       - redis
-      # Added proxy container dependency below. 
-      # It is unclear on when or why it happens, but sometimes NC manages to start before the proxy 
-      #  and it breaks for whatever weird reason resulting in the need of manual proxy container restart.
       - proxy
     networks:
       - proxy-tier
@@ -52,6 +53,9 @@ services:
       - db
       - redis
 
+  # Note: Nginx-proxy is an external service. You can find more information about the configuration here:
+  # Warning: Do not use :latest tags of nginx-proxy unless absolutely sure about the consequences.
+  # https://hub.docker.com/r/nginxproxy/nginx-proxy
   proxy:
     build: ./proxy
     restart: always
@@ -69,6 +73,8 @@ services:
     networks:
       - proxy-tier
 
+  # Note: Letsencrypt companion is an external service. You can find more information about the configuration here:
+  # https://github.com/nginx-proxy/acme-companion/tree/main/docs#readme
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
@@ -85,7 +91,7 @@ services:
     depends_on:
       - proxy
 
-# self signed
+# self signed,outdated
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl
 #    restart: "no"

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginxproxy/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:1.7-alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: MariaDB is an external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     command: --transaction-isolation=READ-COMMITTED
@@ -12,6 +14,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -32,12 +36,15 @@ services:
       - redis
       - proxy
 
+  # Note: Nginx is an external service. You can find more information about the configuration here:
+  # https://hub.docker.com/_/nginx/
   web:
-    build: ./web
+    image: nginx:alpine
     restart: always
     volumes:
+      - ./web/nginx.conf:/etc/nginx/nginx.conf:ro  # https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html
+      # NOTE: The `volumes` included below should match those of the `app` container (unless you know what you're doing)
       - nextcloud:/var/www/html:z,ro
-      # NOTE: The `volumes` included here should match those of the `app` container (unless you know what you're doing)
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -59,6 +66,9 @@ services:
       - db
       - redis
 
+  # Note: Nginx-proxy is an external service. You can find more information about the configuration here:
+  # Warning: Do not use :latest tags of nginx-proxy unless absolutely sure about the consequences.
+  # https://hub.docker.com/r/nginxproxy/nginx-proxy
   proxy:
     build: ./proxy
     restart: always
@@ -75,6 +85,8 @@ services:
     networks:
       - proxy-tier
 
+  # Note: Letsencrypt companion is an external service. You can find more information about the configuration here:
+  # https://github.com/nginx-proxy/acme-companion/tree/main/docs#readme
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
@@ -91,7 +103,7 @@ services:
     depends_on:
       - proxy
 
-# self signed
+# self signed, outdated. 
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl
 #    restart: "no"

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginxproxy/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:1.7-alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/web/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/compose.yaml
@@ -1,4 +1,6 @@
 services:
+  # Note: PostgreSQL is an external service. You can find more information about the configuration here:
+  # https://github.com/docker-library/docs/blob/master/postgres/README.md
   db:
     image: postgres:alpine
     restart: always
@@ -7,6 +9,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -44,6 +48,9 @@ services:
       - db
       - redis
 
+  # Note: Nginx-proxy is an external service. You can find more information about the configuration here:
+  # Warning: Do not use :latest tags of nginx-proxy unless absolutely sure about the consequences.
+  # https://hub.docker.com/r/nginxproxy/nginx-proxy
   proxy:
     build: ./proxy
     restart: always
@@ -60,6 +67,8 @@ services:
     networks:
       - proxy-tier
 
+  # Note: Letsencrypt companion is an external service. You can find more information about the configuration here:
+  # https://github.com/nginx-proxy/acme-companion/tree/main/docs#readme
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
@@ -74,7 +83,7 @@ services:
     depends_on:
       - proxy
 
-# self signed
+# self signed, outdated
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl
 #    restart: "no"

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginxproxy/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:1.7-alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/compose.yaml
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/compose.yaml
@@ -1,6 +1,6 @@
-version: '3'
-
 services:
+  # Note: PostgreSQL is an external service. You can find more information about the configuration here:
+  # https://github.com/docker-library/docs/blob/master/postgres/README.md
   db:
     image: postgres:alpine
     restart: always
@@ -9,6 +9,8 @@ services:
     env_file:
       - db.env
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -29,12 +31,15 @@ services:
       - redis
       - proxy
 
+  # Note: Nginx is an external service. You can find more information about the configuration here:
+  # https://hub.docker.com/_/nginx/
   web:
-    build: ./web
+    image: nginx:alpine
     restart: always
     volumes:
+      - ./web/nginx.conf:/etc/nginx/nginx.conf:ro  # https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html
+      # NOTE: The `volumes` included below should match those of the `app` container (unless you know what you're doing)
       - nextcloud:/var/www/html:z,ro
-      # NOTE: The `volumes` included here should match those of the `app` container (unless you know what you're doing)
     environment:
       - VIRTUAL_HOST=
       - LETSENCRYPT_HOST=
@@ -56,6 +61,9 @@ services:
       - db
       - redis
 
+  # Note: Nginx-proxy is an external service. You can find more information about the configuration here:
+  # Warning: Do not use :latest tags of nginx-proxy unless absolutely sure about the consequences.
+  # https://hub.docker.com/r/nginxproxy/nginx-proxy
   proxy:
     build: ./proxy
     restart: always
@@ -72,6 +80,8 @@ services:
     networks:
       - proxy-tier
 
+  # Note: Letsencrypt companion is an external service. You can find more information about the configuration here:
+  # https://github.com/nginx-proxy/acme-companion/tree/main/docs#readme
   letsencrypt-companion:
     image: nginxproxy/acme-companion
     restart: always
@@ -88,7 +98,7 @@ services:
     depends_on:
       - proxy
 
-# self signed
+# self signed, outdated
 #  omgwtfssl:
 #    image: paulczar/omgwtfssl
 #    restart: "no"

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginxproxy/nginx-proxy:alpine
+FROM nginxproxy/nginx-proxy:1.7-alpine
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/web/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` varia
 
 ```yaml
 services:
+  # Note: MariaDB is external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     restart: always
@@ -415,6 +417,8 @@ services:
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -451,6 +455,8 @@ Make sure to pass in values for `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` varia
 
 ```yaml
 services:
+  # Note: MariaDB is an external service. You can find more information about the configuration here:
+  # https://docs.linuxserver.io/images/docker-mariadb/#environment-variables-e
   db:
     image: mariadb:10.11
     restart: always
@@ -463,6 +469,8 @@ services:
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
 
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always
@@ -481,15 +489,17 @@ services:
       - MYSQL_USER=nextcloud
       - MYSQL_HOST=db
 
+  # Note: Nginx is an external service. You can find more information about the configuration here:
+  # https://hub.docker.com/_/nginx/
   web:
-    image: nginx
+    image: nginx:alpine
     restart: always
     ports:
       - 8080:80
     depends_on:
       - app
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro # https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html
     volumes_from:
       - app
 
@@ -514,6 +524,8 @@ Example:
 
 ```yaml
 services:
+  # Note: PostgreSQL is external service. You can find more information about the configuration here:
+  # https://github.com/docker-library/docs/blob/master/postgres/README.md
   db:
     image: postgres
     restart: always
@@ -527,6 +539,8 @@ services:
       - postgres_db
       - postgres_password
       - postgres_user
+  # Note: Redis is an external service. You can find more information about the configuration here:
+  # https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#configuration
   redis:
     image: redis:alpine
     restart: always


### PR DESCRIPTION
Added documentation links to external services.
Updated web container to use the image and to map nginx conf as volume. Deleted the dockerfiles.
Added link to official nginx.conf docs file inside the compose.
Added 1.7-alpine for all the proxy dockerfiles, using :latest or :alpine is bad idea as per their docs.
Added the word "outdated" to the self-signed variant, still can't figure out what's easy enough and updated enough to be used.
Updated front page Readme. Examples readme looks fine.

/close #2399 #2278 #1994  #2382 #2279 

#1954 That's done too, links to official docs for nginx.conf

I'd close #2196 as well.

Cheers