### PR TITLE
Restore PHP 8.3

### DIFF
--- a/30/apache/Dockerfile
+++ b/30/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-apache-bookworm
+FROM php:8.3-apache-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/30/fpm-alpine/Dockerfile
+++ b/30/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.2-fpm-alpine3.21
+FROM php:8.3-fpm-alpine3.21
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/30/fpm/Dockerfile
+++ b/30/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-fpm-bookworm
+FROM php:8.3-fpm-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/31/apache/Dockerfile
+++ b/31/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-apache-bookworm
+FROM php:8.3-apache-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/31/fpm-alpine/Dockerfile
+++ b/31/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.2-fpm-alpine3.21
+FROM php:8.3-fpm-alpine3.21
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/31/fpm/Dockerfile
+++ b/31/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-fpm-bookworm
+FROM php:8.3-fpm-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,8 @@ declare -A debian_version=(
 )
 
 declare -A php_version=(
-	[default]='8.2'
+	[29]='8.2'
+	[default]='8.3'
 )
 
 declare -A cmd=(

--- a/versions.json
+++ b/versions.json
@@ -9,19 +9,19 @@
         "variant": "apache",
         "base": "debian",
         "baseVersion": "bookworm",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       },
       "fpm": {
         "variant": "fpm",
         "base": "debian",
         "baseVersion": "bookworm",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       },
       "fpm-alpine": {
         "variant": "fpm-alpine",
         "base": "alpine",
         "baseVersion": "3.21",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       }
     }
   },
@@ -35,19 +35,19 @@
         "variant": "apache",
         "base": "debian",
         "baseVersion": "bookworm",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       },
       "fpm": {
         "variant": "fpm",
         "base": "debian",
         "baseVersion": "bookworm",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       },
       "fpm-alpine": {
         "variant": "fpm-alpine",
         "base": "alpine",
         "baseVersion": "3.21",
-        "phpVersion": "8.2"
+        "phpVersion": "8.3"
       }
     }
   },


### PR DESCRIPTION
https://github.com/nextcloud/docker/pull/2417 also reverted ` update.sh`. This restores PHP 8.3 for 31 and also updates it for 30.