### PR TITLE
fix: bump stable to 31.0.8

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-stable_channel='31.0.7'
+stable_channel='31.0.8'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Fixes #2463 

Seems we really should automate this one since we already have version info config elsewhere. 