### PR TITLE
Switch to the repository on github to speedup download and build time.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -107,8 +107,8 @@ function create_variant() {
 	debianVersion=${debian_version[$version]-${debian_version[default]}}
 	phpVersion=${php_version[$version]-${php_version[default]}}
 	crontabInt=${crontab_int[$version]-${crontab_int[default]}}
-	url="https://download.nextcloud.com/server/releases/nextcloud-$fullversion.tar.bz2"
-	ascUrl="https://download.nextcloud.com/server/releases/nextcloud-$fullversion.tar.bz2.asc"
+	url="https://github.com/nextcloud-releases/server/releases/download/v$fullversion/nextcloud-$fullversion.tar.bz2"
+	ascUrl="https://github.com/nextcloud-releases/server/releases/download/v$fullversion/nextcloud-$fullversion.tar.bz2.asc"
 
 	# Create the version+variant directory with a Dockerfile.
 	mkdir -p "$dir"


### PR DESCRIPTION
This PR helps to reduce load on download.nextcloud.com. This achieves the goal of switching to GH, as mentioned in this [comment](https://github.com/nextcloud/server/issues/52895#issuecomment-3043938260) from @provokateurin.