### PR TITLE
Keep the main codebase in container ephemeral storage

### DIFF
--- a/32/apache/Dockerfile
+++ b/32/apache/Dockerfile
@@ -132,7 +132,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 RUN a2enmod headers rewrite remoteip ; \
     { \
@@ -167,12 +171,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     apt-get dist-clean

--- a/32/apache/entrypoint.sh
+++ b/32/apache/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/32/fpm-alpine/Dockerfile
+++ b/32/fpm-alpine/Dockerfile
@@ -125,7 +125,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 
 ENV NEXTCLOUD_VERSION 32.0.7
@@ -143,12 +147,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com  --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     apk del --no-network .fetch-deps
 
 COPY *.sh upgrade.exclude /

--- a/32/fpm-alpine/entrypoint.sh
+++ b/32/fpm-alpine/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/32/fpm/Dockerfile
+++ b/32/fpm/Dockerfile
@@ -132,7 +132,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 
 ENV NEXTCLOUD_VERSION 32.0.7
@@ -152,12 +156,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     apt-get dist-clean

--- a/32/fpm/entrypoint.sh
+++ b/32/fpm/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/33/apache/Dockerfile
+++ b/33/apache/Dockerfile
@@ -132,7 +132,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 RUN a2enmod headers rewrite remoteip ; \
     { \
@@ -167,12 +171,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     apt-get dist-clean

--- a/33/apache/entrypoint.sh
+++ b/33/apache/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/33/fpm-alpine/Dockerfile
+++ b/33/fpm-alpine/Dockerfile
@@ -125,7 +125,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 
 ENV NEXTCLOUD_VERSION 33.0.1
@@ -143,12 +147,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com  --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     apk del --no-network .fetch-deps
 
 COPY *.sh upgrade.exclude /

--- a/33/fpm-alpine/entrypoint.sh
+++ b/33/fpm-alpine/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/33/fpm/Dockerfile
+++ b/33/fpm/Dockerfile
@@ -132,7 +132,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 
 
 ENV NEXTCLOUD_VERSION 33.0.1
@@ -152,12 +156,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     apt-get dist-clean

--- a/33/fpm/entrypoint.sh
+++ b/33/fpm/entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -124,7 +124,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
@@ -142,12 +146,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com  --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     apk del --no-network .fetch-deps
 
 COPY *.sh upgrade.exclude /

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -131,7 +131,11 @@ RUN { \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+VOLUME /var/www/html/data
+VOLUME /var/www/html/config
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/themes
+VOLUME /var/www/tmp
 %%VARIANT_EXTRAS%%
 
 ENV NEXTCLOUD_VERSION %%VERSION%%
@@ -151,12 +155,17 @@ RUN set -ex; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
     tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    mkdir /usr/src/nextcloud-base; \
+    mv -vf /usr/src/nextcloud/config /usr/src/nextcloud/themes /usr/src/nextcloud-base/; \
+    rm -Rvf /var/www/html; \
+    mv -vf /usr/src/nextcloud /var/www/html; \
+    mv -vf /usr/src/nextcloud-base /usr/src/nextcloud; \
     gpgconf --kill all; \
-    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    mkdir -p /var/www/html/data; \
+    mkdir -p /var/www/html/custom_apps; \
+    mkdir -p /var/www/html/themes; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
     apt-get dist-clean

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -174,12 +174,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
         fi
 
         installed_version="0.0.0.0"
-        if [ -f /var/www/html/version.php ]; then
+        if [ -f /var/www/html/config/version.php ]; then
             # shellcheck disable=SC2016
-            installed_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
+            installed_version="$(php -r 'require "/var/www/html/config/version.php"; echo implode(".", $OC_Version);')"
         fi
         # shellcheck disable=SC2016
-        image_version="$(php -r 'require "/usr/src/nextcloud/version.php"; echo implode(".", $OC_Version);')"
+        image_version="$(php -r 'require "/var/www/html/version.php"; echo implode(".", $OC_Version);')"
 
         if version_greater "$installed_version" "$image_version"; then
             echo "Can't start Nextcloud because the version of the data ($installed_version) is higher than the docker image version ($image_version) and downgrading is not supported. Are you sure you have pulled the newest image version?"
@@ -203,13 +203,11 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 rsync_options="-rlD"
             fi
 
-            rsync $rsync_options --delete --exclude-from=/upgrade.exclude /usr/src/nextcloud/ /var/www/html/
             for dir in config data custom_apps themes; do
                 if [ ! -d "/var/www/html/$dir" ] || directory_empty "/var/www/html/$dir"; then
                     rsync $rsync_options --include "/$dir/" --exclude '/*' /usr/src/nextcloud/ /var/www/html/
                 fi
             done
-            rsync $rsync_options --include '/version.php' --exclude '/*' /usr/src/nextcloud/ /var/www/html/
 
             # Install
             if [ "$installed_version" = "0.0.0.0" ]; then
@@ -303,6 +301,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_path post-upgrade
             fi
+
+            cp -vf /var/www/html/version.php /var/www/html/config/
+            chown -c $user:$group /var/www/html/config/version.php
 
             echo "Initializing finished"
         fi


### PR DESCRIPTION
This has several advantages
* Faster startup for initial container and during upgrades
  * On my system (shared storage for `/var/www/html` was cephfs on 2x10Gb network and consumer-grade NVMe drives), updates between 29, 30, 31, and 32 went from ~135 minutes to ~5 minutes.  The main culprits for the difference were the `rsync` step and the code integrity check.
* Improved performance when volume storage is slower than container storage.  This is common in cases where multiple replicas are running - especially on multiple machines, e.g. Kubernetes, because shared mutable network storage is necessarily slower than local.  Even with the Linux filesystem cache, it needs to cache less optimistically than with a local filesystem to ensure consistency.
  * On my system, fully loading the login screen went from ~18 seconds to ~800ms
* More idiomatic container setup - the application is contained in the container.  This means that tampering with application code isn't permanent, without an explicit code integrity check step.

It also _may_ fix #2044; I don't want to speak for the person who originally filed it, but it sounded like they were asking for the same thing.

This is, obviously, a breaking change - anybody currently mounting in all of `/var/www/html` needs to now mount in several subdirectories instead.  I'm not sure whether the breaking change is preferable over the maintenance burden of having a separate set of images; if a separate set of images is desired, I'll redo it that way.  Notably, the helm chart already mounts them all in separately; the only change needed there is to no longer mount in `/var/www` and `/var/www/html`.  I haven't looked for docker-compose files or anything like that.

Other than that, I don't believe I broke anything.  The example theme and any changed "built-in" config/custom apps will still be copied over when the version changes.