### PR TITLE
fix: Revert PHP to 8.3 for v33 and default

### DIFF
--- a/33/apache/Dockerfile
+++ b/33/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.4-apache-trixie
+FROM php:8.3-apache-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -46,7 +46,7 @@ RUN set -ex; \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure ftp --with-ftp-ssl; \
+    docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install -j "$(nproc)" \

--- a/33/fpm-alpine/Dockerfile
+++ b/33/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.4-fpm-alpine3.23
+FROM php:8.3-fpm-alpine3.23
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -42,7 +42,7 @@ RUN set -ex; \
         postgresql-dev \
     ; \
     \
-    docker-php-ext-configure ftp --with-ftp-ssl; \
+    docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install -j "$(nproc)" \

--- a/33/fpm/Dockerfile
+++ b/33/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.4-fpm-trixie
+FROM php:8.3-fpm-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -46,7 +46,7 @@ RUN set -ex; \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure ftp --with-ftp-ssl; \
+    docker-php-ext-configure ftp --with-openssl-dir=/usr; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install -j "$(nproc)" \

--- a/update.sh
+++ b/update.sh
@@ -12,13 +12,13 @@ declare -A debian_version=(
 declare -A php_version=(
 	[31]='8.3'
 	[32]='8.3'
-	[default]='8.4'
+	[default]='8.3'
 )
 
 declare -A ftp_options=(
 	[31]='--with-openssl-dir=/usr'
 	[32]='--with-openssl-dir=/usr'
-	[default]='--with-ftp-ssl'
+	[default]='--with-openssl-dir=/usr'
 )
 
 declare -A cmd=(


### PR DESCRIPTION
Fixes #2540
As long as the PHP bug described in [https://github.com/nextcloud/server/issues/58421](https://github.com/nextcloud/server/issues/58421) is not fixed, revert to PHP 8.3 as the default and for v33.
