### PR TITLE
fix(hooks): incorrect found count/skipped output in mixed exec/non-exec batches 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,10 +50,10 @@ run_path() {
 
             echo "==> Finished executing the script: \"${script_file_path}\""
         done
-        if [ "$found" -lt "1" ]; then
-            echo "==> Skipped: the \"$1\" folder does not contain any valid scripts"
+        if [ "$found" -gt "0" ]; then
+		    echo "=> Completed executing scripts in the \"$1\" folder"
         else
-            echo "=> Completed executing scripts in the \"$1\" folder"
+		    echo "==> Skipped: the \"$1\" folder does not contain any valid scripts"
         fi
     )
 }


### PR DESCRIPTION
The `found` variable is incorrectly decremented for non-executable scripts, which leads to misleading output when a hook folder contains an executable + a non-executable script (output will indicate the folder was fully scripted).

Place two scripts in `before-starting` hook folder: `scriptA.sh` and `scriptB.sh`.
Make sure `scriptA.sh` is properly executable.
Make sure `scriptB.sh` is *not* executable.

before:

```
=> Searching for hook scripts (*.sh) to run, located in the folder "/docker-entrypoint-hooks.d/before-starting"
==> Running the script (cwd: /var/www/html): "/docker-entrypoint-hooks.d/before-starting/scriptA.sh"
hello from scriptA.sh
==> Finished executing the script: "/docker-entrypoint-hooks.d/before-starting/scriptA.sh"
==> The script "/docker-entrypoint-hooks.d/before-starting/scriptB.sh was skipped, because it lacks the executable flag
==> Skipped: the "before-starting" folder does not contain any valid scripts
```

^^^last line

after:

```
=> Searching for hook scripts (*.sh) to run, located in the folder "/docker-entrypoint-hooks.d/before-starting"
==> Running the script (cwd: /var/www/html): "/docker-entrypoint-hooks.d/before-starting/scriptA.sh.sh"
hello from scriptA.sh
==> Finished executing the script: "/docker-entrypoint-hooks.d/before-starting/scriptA.sh"
==> The script "/docker-entrypoint-hooks.d/before-starting/scriptB.sh" was skipped, because it lacks the executable flag
=> Completed executing scripts in the "before-starting" folder
```