### PR TITLE
fix(entrypoint): compare enabled app names to report disabled apps after upgrade

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,6 +83,14 @@ file_env() {
     unset "$fileVar"
 }
 
+get_enabled_apps() {
+    run_as 'php /var/www/html/occ app:list' \
+        | sed -n '/^Enabled:$/,/^Disabled:$/p' \
+        | sed '1d;$d' \
+        | sed -n 's/^  - \([^:]*\):.*/\1/p' \
+        | sort
+}
+
 # Write PHP session config for Redis to /usr/local/etc/php/conf.d/redis-session.ini
 configure_redis_session() {
     echo "=> Configuring PHP session handler..."
@@ -190,7 +198,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     exit 1
                 fi
                 echo "Upgrading nextcloud from $installed_version ..."
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_before
+                get_enabled_apps > /tmp/list_before
             fi
             if [ "$(id -u)" = 0 ]; then
                 rsync_options="-rlDog --chown $user:$group"
@@ -288,9 +296,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
 
                 run_as 'php /var/www/html/occ upgrade'
 
-                run_as 'php /var/www/html/occ app:list' | sed -n "/Enabled:/,/Disabled:/p" > /tmp/list_after
-                echo "The following apps have been disabled:"
-                diff /tmp/list_before /tmp/list_after | grep '<' | cut -d- -f2 | cut -d: -f1
+                get_enabled_apps > /tmp/list_after
+                disabled_apps="$(comm -23 /tmp/list_before /tmp/list_after || true)"
+                if [ -n "$disabled_apps" ]; then
+                    echo "The following apps have been disabled:"
+                    printf '%s\n' "$disabled_apps"
+                fi
                 rm -f /tmp/list_before /tmp/list_after
 
                 run_path post-upgrade


### PR DESCRIPTION
## Summary

Refactor disabled-app reporting in `docker-entrypoint.sh` into a helper and compare normalized enabled app names before and after `occ upgrade`.

Instead of diffing full `occ app:list` output and parsing human-readable `diff` output, this change extracts only enabled app names and compares those sets directly.

## Why

The previous implementation had two problems:

1. **False positives during upgrades**
   - Apps that were upgraded but still enabled could be reported as disabled because the line in `occ app:list` changed (for example due to a version bump), and the script treated that as a removal.
   - e.g. https://github.com/nextcloud/server/issues/56093#issuecomment-3568411701

2. **Alpine / BusyBox incompatibility**
   - The code depended on parsing `diff` output using `grep '<'`, which does not work reliably with BusyBox `diff` output on Alpine.

By comparing only enabled app names, the script now reports actual before-vs-after enablement changes instead of line-level text differences.

## What changed

- Extract disabled-app reporting into a dedicated helper
- Normalize `occ app:list` output down to enabled app names only
- Compare the before/after app-name lists with `comm`
- Keep the upgrade flow behavior the same otherwise

## Behavior before

- `calendar 4.2.2 -> 4.2.3` could be reported as "disabled"
- Alpine images could produce an empty disabled-app list due to `diff` output format differences

## Behavior after

- Upgraded-but-still-enabled apps are no longer reported as disabled
- Disabled-app reporting works without depending on `diff` output format

## Notes

This is both a cleanup and a bug fix:
- the comparison logic is now easier to reason about
- the result matches the actual intent: report apps enabled before upgrade but
  not enabled after upgrade

Fixes #1911

Alternative to PR #2267