### PR TITLE
examples: add healthchecks and service_healthy depends_on to mariadb …

### DIFF
--- a/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
+++ b/.examples/docker-compose/insecure/mariadb/apache/compose.yaml
@@ -15,12 +15,24 @@ services:
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     env_file:
       - db.env
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--innodb_initialized"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   # Note: Redis is an external service. You can find more information about the configuration here:
   # https://hub.docker.com/_/redis
   redis:
     image: redis:alpine
     restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   app:
     image: nextcloud:apache
@@ -36,8 +48,10 @@ services:
     env_file:
       - db.env
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   cron:
     image: nextcloud:apache


### PR DESCRIPTION
## What does this PR do?
Adds healthcheck blocks to the db (MariaDB) and redis services.
Updates depends_on in app and cron to use condition: service_healthy.

## Why?
Without healthchecks, Docker marks a container as ready the moment
it starts, not when it is actually accepting connections. This causes
race conditions on first install where Nextcloud tries to connect to
MariaDB before it has finished initializing.

Closes #2250