### PR TITLE
chore: add OCI standard labels to Dockerfile templates

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -153,5 +153,14 @@ RUN set -ex; \
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/nextcloud/config/
 
+LABEL org.opencontainers.image.title="Nextcloud" \
+      org.opencontainers.image.description="A safe home for all your data. Access & share your files, calendars, contacts, mail & more from any device, on your terms." \
+      org.opencontainers.image.url="https://nextcloud.com" \
+      org.opencontainers.image.source="https://github.com/nextcloud/docker" \
+      org.opencontainers.image.documentation="https://hub.docker.com/_/nextcloud" \
+      org.opencontainers.image.vendor="Nextcloud GmbH" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.version="%%VERSION%%"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -158,7 +158,6 @@ LABEL org.opencontainers.image.title="Nextcloud" \
       org.opencontainers.image.url="https://nextcloud.com" \
       org.opencontainers.image.source="https://github.com/nextcloud/docker" \
       org.opencontainers.image.documentation="https://hub.docker.com/_/nextcloud" \
-      org.opencontainers.image.vendor="Nextcloud GmbH" \
       org.opencontainers.image.licenses="AGPL-3.0-or-later" \
       org.opencontainers.image.version="%%VERSION%%"
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -164,5 +164,14 @@ RUN set -ex; \
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/nextcloud/config/
 
+LABEL org.opencontainers.image.title="Nextcloud" \
+      org.opencontainers.image.description="A safe home for all your data. Access & share your files, calendars, contacts, mail & more from any device, on your terms." \
+      org.opencontainers.image.url="https://nextcloud.com" \
+      org.opencontainers.image.source="https://github.com/nextcloud/docker" \
+      org.opencontainers.image.documentation="https://hub.docker.com/_/nextcloud" \
+      org.opencontainers.image.vendor="Nextcloud GmbH" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.version="%%VERSION%%"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -169,7 +169,6 @@ LABEL org.opencontainers.image.title="Nextcloud" \
       org.opencontainers.image.url="https://nextcloud.com" \
       org.opencontainers.image.source="https://github.com/nextcloud/docker" \
       org.opencontainers.image.documentation="https://hub.docker.com/_/nextcloud" \
-      org.opencontainers.image.vendor="Nextcloud GmbH" \
       org.opencontainers.image.licenses="AGPL-3.0-or-later" \
       org.opencontainers.image.version="%%VERSION%%"
 


### PR DESCRIPTION
## Context

Add [OCI (Open Container Initiative)](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to `Dockerfile-debian.template` and `Dockerfile-alpine.template` for better image metadata and container registry compatibility.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `Nextcloud` | Static |
| `org.opencontainers.image.description` | `A safe home for all your data. Access & share your files, calendars, contacts, mail & more from any device, on your terms.` | Static |
| `org.opencontainers.image.url` | `https://nextcloud.com` | Static |
| `org.opencontainers.image.source` | `https://github.com/nextcloud/docker` | Static |
| `org.opencontainers.image.documentation` | `https://hub.docker.com/_/nextcloud` | Static |
| `org.opencontainers.image.vendor` | `Nextcloud GmbH` | Static |
| `org.opencontainers.image.licenses` | `AGPL-3.0-or-later` | Static |
| `org.opencontainers.image.version` | `%%VERSION%%` → e.g. `33.0.2` | Template variable (existing `sed` substitution) |

The `%%VERSION%%` placeholder is already used in `ENV NEXTCLOUD_VERSION %%VERSION%%` and is replaced globally by `update.sh`, so it works in the `LABEL` instruction with no changes required to `update.sh`.

The LABEL block is placed after the final `COPY` instructions and before `ENTRYPOINT`, which avoids cache invalidation for the expensive build steps above.

## Benefits

- **Registry Compatibility**: GHCR, Docker Hub, and other registries display these labels in their UI
- **Dependency Bot Changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in update PRs
- **Image Provenance**: Track source code and version information for security audits
- **Standardization**: Follow OCI best practices for container image metadata

## Changes

- `Dockerfile-debian.template` — added 8-label LABEL block before `ENTRYPOINT`
- `Dockerfile-alpine.template` — added 8-label LABEL block before `ENTRYPOINT`

The generated Dockerfiles (`32/`, `33/` × `apache/fpm/fpm-alpine`) will be automatically updated on the next run of `update.sh` (triggered by the `update-sh.yml` CI workflow after merge).

## How to verify

After image build:
```
docker inspect <image> --format '{{ json .Config.Labels }}' | jq
```

## References

- [OCI Image Spec - Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker - Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)
