### PR TITLE
fix(entrypoint.sh): Passwords starting with hyphen break `occ mainten…

### DIFF
--- a/32/apache/entrypoint.sh
+++ b/32/apache/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/32/fpm-alpine/entrypoint.sh
+++ b/32/fpm-alpine/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/32/fpm/entrypoint.sh
+++ b/32/fpm/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/33/apache/entrypoint.sh
+++ b/33/apache/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/33/fpm-alpine/entrypoint.sh
+++ b/33/fpm-alpine/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/33/fpm/entrypoint.sh
+++ b/33/fpm/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/34/apache/entrypoint.sh
+++ b/34/apache/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/34/fpm-alpine/entrypoint.sh
+++ b/34/fpm-alpine/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/34/fpm/entrypoint.sh
+++ b/34/fpm/entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -221,7 +221,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                 install=false
                 if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ]; then
                     # shellcheck disable=SC2016
-                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" --admin-pass "$NEXTCLOUD_ADMIN_PASSWORD"'
+                    install_options='-n --admin-user "$NEXTCLOUD_ADMIN_USER" "--admin-pass=$NEXTCLOUD_ADMIN_PASSWORD"'
                     if [ -n "${NEXTCLOUD_DATA_DIR+x}" ]; then
                         # shellcheck disable=SC2016
                         install_options=$install_options' --data-dir "$NEXTCLOUD_DATA_DIR"'
@@ -242,12 +242,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ] || [ "${NEXTCLOUD_UP
                     elif [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_USER+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ]; then
                         echo "Installing with MySQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" --database-pass "$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
+                        install_options=$install_options' --database mysql --database-name "$MYSQL_DATABASE" --database-user "$MYSQL_USER" "--database-pass=$MYSQL_PASSWORD" --database-host "$MYSQL_HOST"'
                         install=true
                     elif [ -n "${POSTGRES_DB+x}" ] && [ -n "${POSTGRES_USER+x}" ] && [ -n "${POSTGRES_PASSWORD+x}" ] && [ -n "${POSTGRES_HOST+x}" ]; then
                         echo "Installing with PostgreSQL database"
                         # shellcheck disable=SC2016
-                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" --database-pass "$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
+                        install_options=$install_options' --database pgsql --database-name "$POSTGRES_DB" --database-user "$POSTGRES_USER" "--database-pass=$POSTGRES_PASSWORD" --database-host "$POSTGRES_HOST"'
                         install=true
                     fi
 


### PR DESCRIPTION
# Issue

If you provide a password starting with a hyphen, the automated installation fails because the `occ` command parses the password value as a new CLI option.

```bash
docker run --rm \
    -e NEXTCLOUD_ADMIN_USER=admin \
    -e NEXTCLOUD_ADMIN_PASSWORD="-starts-with-hyphen" \
    -e SQLITE_DATABASE="sqlite.db" \
    nextcloud:latest

[...]
Starting nextcloud installation
The "--admin-pass" option requires a value.
[fails ten more times]
```

# Fix

1. Use `option=value` syntax in `entrypoint.sh` for passwords to ensure passwords starting with hyphens aren't parsed as a new option.

## Testing

```bash
docker run --rm \
    -e NEXTCLOUD_ADMIN_USER=admin \
    -e NEXTCLOUD_ADMIN_PASSWORD="-starts-with-hyphen" \
    -e SQLITE_DATABASE="sqlite.db" \
    local/nextcloud:latest 

[...]
Starting nextcloud installation
Nextcloud was successfully installed
[...]
```

* I verified the same behavior and fix applies to database passwords (MYSQL_PASSWORD, POSTGRES_PASSWORD)

* Note: The same `option=value` pattern could also be applied to the other params for additional robustness. I'm happy to extend this PR if desired.