### PR TITLE
Adding support for DBINDEX redis config value

### DIFF
--- a/.config/redis.config.php
+++ b/.config/redis.config.php
@@ -18,4 +18,8 @@ if (getenv('REDIS_HOST')) {
   if (getenv('REDIS_HOST_USER') !== false) {
     $CONFIG['redis']['user'] = (string) getenv('REDIS_HOST_USER');
   }
+
+  if (getenv('REDIS_HOST_DB') !== false) {
+    $CONFIG['redis']['dbindex'] = (int) getenv('REDIS_HOST_DB');
+  }
 }

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ To use Redis for memory caching as well as PHP session storage, specify the foll
 - `REDIS_HOST_PORT` (default: `6379`) Optional port for Redis, only use for external Redis servers that run on non-standard ports.
 - `REDIS_HOST_USER` (not set by default) Optional username for Redis, only use for external Redis servers that require a user.
 - `REDIS_HOST_PASSWORD` (not set by default) Redis password
+- `REDIS_HOST_DB` (default: `0`) Index of the Redis database to use, set dbindex parameter in the redis config file for Nextcloud.
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/caching_configuration.html) for more information.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -104,10 +104,10 @@ configure_redis_session() {
 
     case "$REDIS_HOST" in
         /*)
-            redis_save_path="unix://${REDIS_HOST}"
+            redis_save_path="unix://${REDIS_HOST}/${REDIS_HOST_DB:=0}"
             ;;
         *)
-            redis_save_path="tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}"
+            redis_save_path="tcp://${REDIS_HOST}:${REDIS_HOST_PORT:=6379}/${REDIS_HOST_DB:=0}"
             ;;
     esac
 


### PR DESCRIPTION
As discussed in #2288 , #2236 and #1286  It would be usefull to add the possibility to set dbindex parameter if needed.
Even if it is not the most usefull parameter of redis, it is still supported by redis and users may want to use it.
The default value of dbindex that is already used silently is 0.
I suggest to add this possibilty while keeping the default at 0 in order to prevent current users from any changes and let the possibility to those who want it to customize this parameter via an environment variable.

As the #2288 is a little old I will propose a new PR.

Closes #2593 