### PR TITLE
Add S3 SSE-KMS environment variable support

### DIFF
--- a/.config/s3.config.php
+++ b/.config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/32/apache/config/s3.config.php
+++ b/32/apache/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/32/fpm-alpine/config/s3.config.php
+++ b/32/fpm-alpine/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/32/fpm/config/s3.config.php
+++ b/32/fpm/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/33/apache/config/s3.config.php
+++ b/33/apache/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/33/fpm-alpine/config/s3.config.php
+++ b/33/fpm-alpine/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/33/fpm/config/s3.config.php
+++ b/33/fpm/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/34/apache/config/s3.config.php
+++ b/34/apache/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/34/fpm-alpine/config/s3.config.php
+++ b/34/fpm-alpine/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/34/fpm/config/s3.config.php
+++ b/34/fpm/config/s3.config.php
@@ -45,4 +45,14 @@ if (getenv('OBJECTSTORE_S3_BUCKET')) {
   } elseif (getenv('OBJECTSTORE_S3_SSE_C_KEY')) {
     $CONFIG['objectstore']['arguments']['sse_c_key'] = getenv('OBJECTSTORE_S3_SSE_C_KEY');
   }
+
+  $sse_kms_enabled = getenv('OBJECTSTORE_S3_SSE_KMS_ENABLED');
+  $sse_kms_key_id = getenv('OBJECTSTORE_S3_SSE_KMS_KEY_ID');
+  // Setting a key id implies enabling SSE-KMS; the flag alone uses the bucket default key.
+  if ($sse_kms_key_id || ($sse_kms_enabled && strtolower($sse_kms_enabled) !== 'false')) {
+    $CONFIG['objectstore']['arguments']['sse_kms_enabled'] = true;
+    if ($sse_kms_key_id) {
+      $CONFIG['objectstore']['arguments']['sse_kms_key_id'] = $sse_kms_key_id;
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ To use an external S3 compatible object store as primary storage, set the follow
 - `OBJECTSTORE_S3_OBJECT_PREFIX` (default: `urn:oid:`): Prefix to prepend to the fileid
 - `OBJECTSTORE_S3_AUTOCREATE` (default: `true`): Create the container if it does not exist
 - `OBJECTSTORE_S3_SSE_C_KEY` (not set by default): Base64 encoded key with a maximum length of 32 bytes for server side encryption (SSE-C)
+- `OBJECTSTORE_S3_SSE_KMS_ENABLED` (not set by default): Enable AWS server-side encryption with KMS (SSE-KMS) using the bucket's default KMS key
+- `OBJECTSTORE_S3_SSE_KMS_KEY_ID` (not set by default): KMS key ARN/ID to use for SSE-KMS; setting this implies SSE-KMS is enabled. Requires a Nextcloud server version that includes SSE-KMS support (server 34+)
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) for more information.
 


### PR DESCRIPTION
## Summary
- Nextcloud server PR [nextcloud/server#57623](https://github.com/nextcloud/server/pull/57623) added `sse_kms_enabled` and `sse_kms_key_id` `objectstore` arguments to support AWS Server-Side Encryption with KMS (SSE-KMS) for S3 primary storage.
- Expose this via two new environment variables, mirroring the existing SSE-C support:
  - `OBJECTSTORE_S3_SSE_KMS_ENABLED`: enables SSE-KMS using the bucket's default KMS key
  - `OBJECTSTORE_S3_SSE_KMS_KEY_ID`: specific KMS key ARN/ID to use; setting this implies SSE-KMS is enabled
- Updated `.config/s3.config.php` (source template) and regenerated all versioned copies via `./update.sh`.
- Documented both new variables in `README.md` alongside the existing SSE-C entry.

## Test plan
- [x] `php -l` on the source template and a regenerated copy
- [x] Confirmed all versioned `s3.config.php` copies remain byte-identical to `.config/s3.config.php`
- [x] Verified env var matrix behavior (unset, enabled-only, key-id-only, disabled, disabled-with-key-id) produces the expected `objectstore` arguments
- [x] End-to-end test against a real S3 bucket + KMS key on a Nextcloud server version that includes the SSE-KMS support (server 34+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)