### PR TITLE
Allow configuring the cron.php schedule

### DIFF
--- a/32/apache/cron.sh
+++ b/32/apache/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/32/fpm-alpine/cron.sh
+++ b/32/fpm-alpine/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/32/fpm/cron.sh
+++ b/32/fpm/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/33/apache/cron.sh
+++ b/33/apache/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/33/fpm-alpine/cron.sh
+++ b/33/fpm-alpine/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/33/fpm/cron.sh
+++ b/33/fpm/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/34/apache/cron.sh
+++ b/34/apache/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/34/fpm-alpine/cron.sh
+++ b/34/fpm-alpine/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/34/fpm/cron.sh
+++ b/34/fpm/cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A safe home for all your data. Access & share your files, calendars, contacts, m
     - [Custom Data directory (`datadirectory`)](#custom-data-directory-datadirectory)
     - [Trusted domains (`trusted_domains`)](#trusted-domains-trusted_domains)
     - [Image specific](#image-specific)
+    - [Background jobs (`cron.php`)](#background-jobs-cronphp)
     - [Redis Memory Caching](#redis-memory-caching)
     - [E-mail (SMTP) Configuration](#e-mail-smtp-configuration)
     - [Object Storage (Primary Storage)](#object-storage-primary-storage)
@@ -280,6 +281,18 @@ The install and update script is only triggered when a default command is used (
 You might want to make sure the htaccess is up to date after each container update. Especially on multiple swarm nodes as any discrepancy will make your server unusable.
 
 - `NEXTCLOUD_INIT_HTACCESS` (not set by default) Set it to true to enable run `occ maintenance:update:htaccess` after container initialization.
+
+### Background jobs (`cron.php`)
+
+The images ship a `/cron.sh` entrypoint that runs `php -f /var/www/html/cron.php` every 5 minutes via busybox `crond`. To run the background jobs less often, override the schedule with a standard five-field cron expression:
+
+- `NEXTCLOUD_CRON_SCHEDULE` (default: `*/5 * * * *`) Cron expression for `cron.php`.
+
+```console
+$ docker run -d --volumes-from app -e NEXTCLOUD_CRON_SCHEDULE='*/30 * * * *' --entrypoint /cron.sh nextcloud
+```
+
+Note that Nextcloud's admin overview reports a warning once the last background job ran more than an hour ago, and jobs such as calendar event reminders are delayed by up to one interval. `TZ` applies to the schedule, so it is evaluated in the container's local time.
 
 ### Redis Memory Caching
 

--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -eu
 
-exec busybox crond -f -L /dev/stdout
+crontabs=/var/spool/cron/crontabs
+
+if [ -n "${NEXTCLOUD_CRON_SCHEDULE:-}" ]; then
+	crontabs="${TMPDIR:-/tmp}/nextcloud-crontabs"
+	mkdir -p "$crontabs"
+	echo "$NEXTCLOUD_CRON_SCHEDULE php -f /var/www/html/cron.php" > "$crontabs/www-data"
+fi
+
+exec busybox crond -f -L /dev/stdout -c "$crontabs"


### PR DESCRIPTION
The interval for cron.php is baked into the image at build time as */5 * * * * in /var/spool/cron/crontabs/www-data, and cron.sh offers no configuration at all. Changing it currently requires replacing the entrypoint and reimplementing the crond invocation downstream.

Add NEXTCLOUD_CRON_SCHEDULE, honoured by /cron.sh. When set, the crontab is written to a writable directory and crond is pointed at it with -c, so the baked crontab stays in place and an image update cannot silently restore the old interval. When unset, -c receives busybox crond's own default directory, so the behaviour is unchanged. Rewriting the baked crontab in place is not an option because it is owned by root with mode 644 and therefore not writable when the container runs as an arbitrary user.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
